### PR TITLE
Don't set `write protect` bit when enabling paging

### DIFF
--- a/posts/2015-08-25-entering-longmode.md
+++ b/posts/2015-08-25-entering-longmode.md
@@ -316,7 +316,6 @@ enable_paging:
     ; enable paging in the cr0 register
     mov eax, cr0
     or eax, 1 << 31
-    or eax, 1 << 16
     mov cr0, eax
 
     ret

--- a/src/arch/x86_64/boot.asm
+++ b/src/arch/x86_64/boot.asm
@@ -86,7 +86,6 @@ enable_paging:
     ; enable paging in the cr0 register
     mov eax, cr0
     or eax, 1 << 31
-    or eax, 1 << 16
     mov cr0, eax
 
     ret


### PR DESCRIPTION
Don't set the `write protect` bit as we don't need it now. Resolves #47 .