### PR TITLE
Don't derive Copy/Clone for Frame so we can be sure that it's free

### DIFF
--- a/src/memory/area_frame_allocator.rs
+++ b/src/memory/area_frame_allocator.rs
@@ -51,7 +51,9 @@ impl AreaFrameAllocator {
 impl FrameAllocator for AreaFrameAllocator {
     fn allocate_frame(&mut self) -> Option<Frame> {
         if let Some(area) = self.current_area {
-            let frame = self.next_free_frame;
+            // "clone" the frame to return it if it's free. Frame doesn't
+            // implement Clone, but we can construct an identical frame.
+            let frame = Frame{ number: self.next_free_frame.number };
 
             // the last frame of the current area
             let current_area_last_frame = {

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -4,7 +4,7 @@ mod area_frame_allocator;
 
 pub const PAGE_SIZE: usize = 4096;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Frame {
     number: usize,
 }


### PR DESCRIPTION
If a Frame would be clonable or even Copy, the frame could be freed (e.g. passed to deallocate_frame) and used thereafter. Or it could be freed multiple times.