### PR TITLE
Specify `raw` ISO format explicitely to avoid QEMU warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean:
 	@rm -rf build
 
 run: $(iso)
-	@qemu-system-x86_64 -hda $(iso)
+	@qemu-system-x86_64 -drive format=raw,file=$(iso)
 
 iso: $(iso)
 

--- a/posts/2015-08-18-multiboot-kernel.md
+++ b/posts/2015-08-18-multiboot-kernel.md
@@ -209,7 +209,7 @@ Now it's time to boot our OS. We will use [QEMU]:
 [QEMU]: https://en.wikipedia.org/wiki/QEMU
 
 ```
-qemu-system-x86_64 -hda os.iso
+qemu-system-x86_64 -drive format=raw,file=os.iso
 ```
 ![qemu output](/images/qemu-ok.png)
 
@@ -263,7 +263,7 @@ clean:
     @rm -r build
 
 run: $(iso)
-    @qemu-system-x86_64 -hda $(iso)
+    @qemu-system-x86_64 -drive format=raw,file=$(iso)
 
 iso: $(iso)
 

--- a/posts/2015-09-02-setup-rust.md
+++ b/posts/2015-09-02-setup-rust.md
@@ -231,7 +231,7 @@ Such a boot loop is most likely caused by some [CPU exception][exception table].
 [Triple Fault]: http://wiki.osdev.org/Triple_Fault
 
 ```
-> qemu-system-x86_64 -d int -no-reboot -hda build/os-x86_64.iso
+> qemu-system-x86_64 -d int -no-reboot -drive format=raw,file=build/os-x86_64.iso
 SMM: enter
 ...
 SMM: after RSM


### PR DESCRIPTION
Warning occurs in QEMU 2.3.0. It looks like this:

```
WARNING: Image format was not specified for 'build/os-x86_64.iso' and probing guessed raw. 
Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted. 
Specify the 'raw' format explicitly to remove the restrictions. 
```

So QEMU does not allow writing to block 0 if we auto detect the image type. It seems like QEMU uses block 0 to perform the autodetection, so writing some random bytes to it could cause an accidental image type change on the next start. See the [QEMU changelog](http://wiki.qemu.org/ChangeLog/2.3#Block_devices_in_system_emulation) for (a bit) more information.

We can fix this by specifying the format explicitely through `format=raw`. Thus the autodetection is disabled and block 0 is writable again. It eliminates the warning, too.
