### PR TITLE
Use `-cdrom` instead of `-drive` as it's shorter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ clean:
 	@rm -rf build
 
 run: $(iso)
-	@qemu-system-x86_64 -drive format=raw,file=$(iso) -s
+	@qemu-system-x86_64 -cdrom $(iso) -s
 
 debug: $(iso)
-	@qemu-system-x86_64 -drive format=raw,file=$(iso) -s -S
+	@qemu-system-x86_64 -cdrom $(iso) -s -S
 
 gdb:
 	@rust-os-gdb/bin/rust-gdb "build/kernel-x86_64.bin" -ex "target remote :1234"

--- a/pages/set-up-gdb.md
+++ b/pages/set-up-gdb.md
@@ -9,7 +9,7 @@ To make QEMU listen for a gdb connection, we add the `-s` flag to the `run` targ
 
 ```make
 run: $(iso)
-	@qemu-system-x86_64 -drive format=raw,file=$(iso) -s
+	@qemu-system-x86_64 -cdrom $(iso) -s
 ```
 This allows us to connect a debugger at any time, for example to investigate why a panic occurred.
 
@@ -17,7 +17,7 @@ To wait for a debugger connection on startup, we add a `debug` target to the Mak
 
 ```make
 debug: $(iso)
-	@qemu-system-x86_64 -drive format=raw,file=$(iso) -s -S
+	@qemu-system-x86_64 -cdrom $(iso) -s -S
 ```
 It is identical to the `run` target except for the additional `-S` flag. This flag causes QEMU to freeze on startup and wait until a debugger is connected. Now it _should_ be possible to connect gdb.
 

--- a/posts/2015-08-18-multiboot-kernel.md
+++ b/posts/2015-08-18-multiboot-kernel.md
@@ -214,7 +214,7 @@ Now it's time to boot our OS. We will use [QEMU]:
 [QEMU]: https://en.wikipedia.org/wiki/QEMU
 
 ```
-qemu-system-x86_64 -drive format=raw,file=os.iso
+qemu-system-x86_64 -cdrom os.iso
 ```
 ![qemu output](/images/qemu-ok.png)
 
@@ -268,7 +268,7 @@ clean:
     @rm -r build
 
 run: $(iso)
-    @qemu-system-x86_64 -drive format=raw,file=$(iso)
+    @qemu-system-x86_64 -cdrom $(iso)
 
 iso: $(iso)
 

--- a/posts/2015-09-02-set-up-rust.md
+++ b/posts/2015-09-02-set-up-rust.md
@@ -232,7 +232,7 @@ Such a boot loop is most likely caused by some [CPU exception][exception table].
 [Triple Fault]: http://wiki.osdev.org/Triple_Fault
 
 ```
-> qemu-system-x86_64 -d int -no-reboot -drive format=raw,file=build/os-x86_64.iso
+> qemu-system-x86_64 -d int -no-reboot -cdrom build/os-x86_64.iso
 SMM: enter
 ...
 SMM: after RSM

--- a/posts/2016-01-01-remap-the-kernel.md
+++ b/posts/2016-01-01-remap-the-kernel.md
@@ -707,7 +707,7 @@ A QEMU boot load indicates that some CPU exception occured. We can see all throw
 [qemu debugging]: {% post_url 2015-09-02-set-up-rust %}#debugging
 
 ```bash
-> qemu-system-x86_64 -d int -no-reboot -drive format=raw,file=build/os-x86_64.iso
+> qemu-system-x86_64 -d int -no-reboot -cdrom build/os-x86_64.iso
 ...
 check_exception old: 0xffffffff new 0xe
      0: v=0e e=0002 i=0 cpl=0 IP=0008:000000000010ab97 pc=000000000010ab97


### PR DESCRIPTION
Right now, it does not matter whether we boot from a drive or a cdrom. Therefore we use the shorter `-cdrom`. Note that `-hda` would generate a warning in newer QEMU versions (see #56).

Fixes #101 