### PR TITLE
Identity map the multiboot structure to fix the frame allocator

### DIFF
--- a/posts/2016-01-01-remap-the-kernel.md
+++ b/posts/2016-01-01-remap-the-kernel.md
@@ -8,6 +8,14 @@ As always, you can find the source code on [Github]. Don't hesitate to file issu
 
 [Github]: https://github.com/phil-opp/blog_os/tree/remap_the_kernel
 
+_Updates_: The `AreaFrameAllocator` [was broken][areaframeallocator broken] after switching to a new table. To fix this, we added the [Fixing the Frame Allocator] section and updated the [linker script][linker script update]. For a complete set of changes see [#131] and [this diff][#131-changes].
+
+[areaframeallocator broken]: https://github.com/phil-opp/blog_os/issues/126
+[Fixing the Frame Allocator]: #fixing-the-frame-allocator
+[linker script update]: #page-align-sections
+[#131]: https://github.com/phil-opp/blog_os/pull/131
+[#131-changes]: https://github.com/phil-opp/blog_os/compare/75aa669cdbb427c7bf0485c68692d243065cd3e9...635f7d3f9dced752f84d429e1d51f5c2b29854e3
+
 ## Motivation
 
 In the [previous post], we had a strange bug in the `unmap` function. Its reason was a silent stack overflow, which corrupted the page tables. Fortunately, our kernel stack is right above the page tables so that we noticed the overflow relatively quickly. This won't be the case when we add threads with new stacks in the future. Then a silent stack overflow could overwrite some data without us noticing. But eventually some completely unrelated function fails because a variable changed its value.

--- a/src/arch/x86_64/linker.ld
+++ b/src/arch/x86_64/linker.ld
@@ -14,28 +14,39 @@ ENTRY(start)
 SECTIONS {
   . = 1M;
 
-  .rodata : ALIGN(4K)
+  .rodata :
   {
     /* ensure that the multiboot header is at the beginning */
     KEEP(*(.multiboot_header))
     *(.rodata .rodata.*)
+    . = ALIGN(4K);
   }
 
-  .text : ALIGN(4K)
+  .text :
   {
     *(.text .text.*)
+    . = ALIGN(4K);
   }
 
-  .data : ALIGN(4K)
+  .data :
   {
     *(.data .data.*)
+    . = ALIGN(4K);
+  }
+
+  .bss :
+  {
+    *(.bss .bss.*)
+    . = ALIGN(4K);
   }
 
   .data.rel.ro : ALIGN(4K) {
     *(.data.rel.ro.local*) *(.data.rel.ro .data.rel.ro.*)
+    . = ALIGN(4K);
   }
 
   .gcc_except_table : ALIGN(4K) {
     *(.gcc_except_table)
+    . = ALIGN(4K);
   }
 }


### PR DESCRIPTION
This PR adds an “Fixing the Frame Allocator” section to fix #126. It avoids the [multiboot-structure-between-kernel-sections-issue](https://github.com/phil-opp/blog_os/issues/126#issuecomment-176907574) by making the section size a multiple of the page size (instead of only aligning the section _start_ as before).

An alternative to this PR would be to debug and fix it in the upcoming post. The debugging steps could be pretty interesting. But I don't have the time right now and I'm not sure if it's interesting enough for outsiders…

cc @mmalone

**TODO:**

- [ ] Add a link to code changes for people that want to update their code. (something like https://github.com/phil-opp/blog_os/compare/remap-the-kernel-update)

Fixes #126 