### PR TITLE
Fix bug in frame iteration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 
 #![feature(lang_items)]
 #![feature(const_fn, unique)]
-#![feature(step_by)]
 #![no_std]
 
 extern crate rlibc;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -33,6 +33,32 @@ impl Frame {
     fn clone(&self) -> Frame {
         Frame { number: self.number }
     }
+
+    fn range_inclusive(start: Frame, end: Frame) -> FrameIter {
+        FrameIter {
+            start: start,
+            end: end,
+        }
+    }
+}
+
+struct FrameIter {
+    start: Frame,
+    end: Frame,
+}
+
+impl Iterator for FrameIter {
+    type Item = Frame;
+
+    fn next(&mut self) -> Option<Frame> {
+        if self.start <= self.end {
+            let frame = self.start.clone();
+            self.start.number += 1;
+            Some(frame)
+        } else {
+            None
+        }
+    }
 }
 
 pub trait FrameAllocator {

--- a/src/memory/paging/mod.rs
+++ b/src/memory/paging/mod.rs
@@ -144,8 +144,6 @@ impl InactivePageTable {
 pub fn remap_the_kernel<A>(allocator: &mut A, boot_info: &BootInformation)
     where A: FrameAllocator
 {
-    use core::ops::Range;
-
     let mut temporary_page = TemporaryPage::new(Page { number: 0xcafebabe }, allocator);
 
     let mut active_table = unsafe { ActivePageTable::new() };


### PR DESCRIPTION
The old code used `range.step_by(PAGE_SIZE)` to iterate over all frames in a section. This was wrong because a section could be smaller than `PAGE_SIZE` but span 2 frames nonetheless. For example: the multiboot section is 1554 bytes and goes from `0x155e60` to `0x156468`. Then the `range.step_by` method would only return the first frame.

The new code adds a `Frame::range_inclusive`, which allows iterating over the frames directly. The post contains an explanation why we avoid [core::ops::Range](https://doc.rust-lang.org/nightly/core/ops/struct.Range.html).

This is a major update, so we set the `updated` tag of _Remap the Kernel_.