### PR TITLE
Add missing `use` statements in printing-to-screen

### DIFF
--- a/blog/post/2015-10-23-printing-to-screen.md
+++ b/blog/post/2015-10-23-printing-to-screen.md
@@ -132,6 +132,8 @@ Since the field ordering in default structs is undefined in Rust, we need the [r
 To actually write to screen, we now create a writer type:
 
 ```rust
+use core::ptr::Unique;
+
 pub struct Writer {
     column_position: usize,
     color_code: ColorCode,
@@ -256,6 +258,7 @@ Now we can use Rust's built-in `write!`/`writeln!` formatting macros:
 
 ```rust
 // in the `print_something` function
+use core::fmt::Write;
 let mut writer = Writer {...};
 writer.write_byte(b'H');
 writer.write_str("ello! ");


### PR DESCRIPTION
Although minor, I've added some missing `use` statements to the code examples in the VGA buffer entry