### PR TITLE
Use the “Consolas” font instead of “Courier New” for code blocks

### DIFF
--- a/static/css/poole.css
+++ b/static/css/poole.css
@@ -147,7 +147,7 @@ abbr[title] {
 /* Code */
 code,
 pre {
-  font-family: Menlo, Monaco, "Courier New", monospace;
+  font-family: Menlo, Monaco, Consolas, monospace;
 }
 code {
   padding: .25em .5em;


### PR DESCRIPTION
IMO it looks nicer on Windows :)