### PR TITLE
Update section header to reflect changes in the text

### DIFF
--- a/blog/post/2015-09-02-set-up-rust.md
+++ b/blog/post/2015-09-02-set-up-rust.md
@@ -204,7 +204,7 @@ What happened? Well, the linker removed unused sections. And since we don't use 
 ```
 Now everything should work again (the green `OKAY`). But there is another linking issue, which is triggered by some other example code.
 
-### no-landing-pads
+### panic == abort
 
 The following snippet still fails:
 


### PR DESCRIPTION
Someone in `#rust-osdev` was following along, and while you no longer use `-Zno-landing-pads`, the title still talked about it. I don't know if you wanted to keep it, or use something else, but here's a suggestion :smile: 