### PR TITLE
Remove unneeded gcc_except_table section

### DIFF
--- a/blog/post/2016-01-01-remap-the-kernel.md
+++ b/blog/post/2016-01-01-remap-the-kernel.md
@@ -683,11 +683,6 @@ SECTIONS {
     *(.data.rel.ro.local*) *(.data.rel.ro .data.rel.ro.*)
     . = ALIGN(4K);
   }
-
-  .gcc_except_table : ALIGN(4K) {
-    *(.gcc_except_table)
-    . = ALIGN(4K);
-  }
 }
 ```
 Instead of page aligning the `.multiboot_header` section, we merge it into the `.rodata` section. That way, we don't waste a whole page for the few bytes of the Multiboot header. We could merge it into any section, but `.rodata` fits best because it has the same flags (neither writable nor executable). The Multiboot header still needs to be at the beginning of the file, so `.rodata` must be our first section now.

--- a/src/arch/x86_64/linker.ld
+++ b/src/arch/x86_64/linker.ld
@@ -44,9 +44,4 @@ SECTIONS {
     *(.data.rel.ro.local*) *(.data.rel.ro .data.rel.ro.*)
     . = ALIGN(4K);
   }
-
-  .gcc_except_table : ALIGN(4K) {
-    *(.gcc_except_table)
-    . = ALIGN(4K);
-  }
 }


### PR DESCRIPTION
No longer needed because we use `panic=abort` now.