### PR TITLE
Catch divide error instead of page fault

### DIFF
--- a/blog/post/2016-05-28-catching-exceptions.md
+++ b/blog/post/2016-05-28-catching-exceptions.md
@@ -660,22 +660,4 @@ We use the built-in [format_args] macro to translate the error string to a `fmt:
 ![QEMU screenshot with new red `EXCEPTION: PAGE BY ZERO` message](images/qemu-divide-error-red.png)
 
 ## What's next?
-Now we're able to catch _almost_ all page faults. However, some page faults still cause a triple fault and a bootloop. For example, try the following code:
-
-```rust
-pub extern "C" fn rust_main(...) {
-    ...
-    interrupts::init();
-
-    // provoke a kernel stack overflow, which hits the guard page
-    fn recursive() {
-        recursive();
-    }
-    recursive();
-
-    println!("It did not crash!");
-    loop {}
-}
-```
-
-The next post will explore and fix this triple fault by creating a double fault handler. After that, we should never again experience a triple fault in our kernel.
+We've successfully caught our first exception! However, our `EXCEPTION: DIVIDE BY ZERO` message doesn't contain much information about the cause of the exception. The next post improves the situation by printing i.a. the current stack pointer and address of the causing instruction. We will also explore other exceptions such as page faults, for which the CPU pushes an _error code_ on the stack.

--- a/src/interrupts/mod.rs
+++ b/src/interrupts/mod.rs
@@ -4,7 +4,7 @@ lazy_static! {
     static ref IDT: idt::Idt = {
         let mut idt = idt::Idt::new();
 
-        idt.set_handler(14, page_fault_handler);
+        idt.set_handler(0, divide_by_zero_handler);
 
         idt
     };
@@ -16,7 +16,7 @@ pub fn init() {
 
 use vga_buffer::print_error;
 
-extern "C" fn page_fault_handler() -> ! {
-    unsafe { print_error(format_args!("EXCEPTION: PAGE FAULT")) };
+extern "C" fn divide_by_zero_handler() -> ! {
+    unsafe { print_error(format_args!("EXCEPTION: DIVIDE BY ZERO")) };
     loop {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(lang_items)]
 #![feature(const_fn, unique)]
 #![feature(alloc, collections)]
+#![feature(asm)]
 #![no_std]
 
 extern crate rlibc;
@@ -49,8 +50,12 @@ pub extern "C" fn rust_main(multiboot_information_address: usize) {
     // initialize our IDT
     interrupts::init();
 
-    // provoke a page fault inside println
-    println!("{:?}", unsafe{ *(0xdeadbeaf as *mut u64) = 42 });
+    fn divide_by_zero() {
+        unsafe { asm!("mov dx, 0; div dx" ::: "ax", "dx" : "volatile", "intel") }
+    }
+
+    // provoke a divide by zero fault inside println
+    println!("{:?}", divide_by_zero());
 
     println!("It did not crash!");
     loop {}


### PR DESCRIPTION
The divide error pushes no error code. Thus we avoid stack misalignment.

Fixes #184