### PR TITLE
Add ENTRY(start) to 'Allocating Frames' blog post linker script

### DIFF
--- a/blog/post/2015-11-15-allocating-frames.md
+++ b/blog/post/2015-11-15-allocating-frames.md
@@ -142,6 +142,8 @@ But when we execute it, tons of really small sections are printed. We can use th
 To merge these subsections, we need to update our linker script:
 
 ```
+ENTRY(start)
+
 SECTIONS {
     . = 1M;
 


### PR DESCRIPTION
The updated linker script shown in the blog post is missing the `ENTRY(start)` line. If a reader replaces their linker script with the one shown, instead of only replacing the `SECTIONS` block, the script will no longer function.