### PR TITLE
Add aligned .got and .got.plt sections to linker script

### DIFF
--- a/blog/post/2016-01-01-remap-the-kernel.md
+++ b/blog/post/2016-01-01-remap-the-kernel.md
@@ -650,6 +650,8 @@ To put all sections on their own page, we add the `ALIGN` statement to all of th
 ```
 /* src/arch/x86_64/linker.ld */
 
+ENTRY(start)
+
 SECTIONS {
   . = 1M;
 
@@ -676,6 +678,18 @@ SECTIONS {
   .bss :
   {
     *(.bss .bss.*)
+    . = ALIGN(4K);
+  }
+
+  .got :
+  {
+    *(.got)
+    . = ALIGN(4K);
+  }
+
+  .got.plt :
+  {
+    *(.got.plt)
     . = ALIGN(4K);
   }
 

--- a/src/arch/x86_64/linker.ld
+++ b/src/arch/x86_64/linker.ld
@@ -40,6 +40,18 @@ SECTIONS {
     . = ALIGN(4K);
   }
 
+  .got :
+  {
+    *(.got)
+    . = ALIGN(4K);
+  }
+
+  .got.plt :
+  {
+    *(.got.plt)
+    . = ALIGN(4K);
+  }
+
   .data.rel.ro : ALIGN(4K) {
     *(.data.rel.ro.local*) *(.data.rel.ro .data.rel.ro.*)
     . = ALIGN(4K);


### PR DESCRIPTION
These sections suddenly appeared on a newer compiler…