### PR TITLE
Display a Table of Contents on large displays

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -54,6 +54,11 @@
           prefix: 'toc'
       });
 
+      var heading = document.createElement("H2");
+      var heading_text = document.createTextNode("Table of Contents");
+      heading.appendChild(heading_text);
+
+      container.appendChild(heading);
       container.appendChild(toc);
     }
   </script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -30,12 +30,31 @@
 
   <!-- JS -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/2.0.0/anchor.min.js"></script>
+  <script src="js/toc.min.js"></script>
   {{ partial "analytics.html" . }}
 
   <!-- redirect from phil-opp.github.io/blog_os -->
   <script type="text/javascript">
     if (window.location.hostname == "phil-opp.github.io") {
       window.location.href = "http://os.phil-opp.com/";
+    }
+
+    window.onload = function() {
+      var container = document.querySelector('#toc');
+
+      var selector = "h2";
+      if (container.className.split(" ").indexOf("coarse") == -1) {
+        selector += ",h3";
+      }
+
+      var toc = initTOC({
+          selector: selector,
+          scope: '.post',
+          overwrite: false,
+          prefix: 'toc'
+      });
+
+      container.appendChild(toc);
     }
   </script>
 </head>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,35 +31,13 @@
   <!-- JS -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/2.0.0/anchor.min.js"></script>
   <script src="js/toc.min.js"></script>
+  <script src="js/main.js"></script>
   {{ partial "analytics.html" . }}
 
   <!-- redirect from phil-opp.github.io/blog_os -->
   <script type="text/javascript">
     if (window.location.hostname == "phil-opp.github.io") {
       window.location.href = "http://os.phil-opp.com/";
-    }
-
-    window.onload = function() {
-      var container = document.querySelector('#toc');
-
-      var selector = "h2";
-      if (container.className.split(" ").indexOf("coarse") == -1) {
-        selector += ",h3";
-      }
-
-      var toc = initTOC({
-          selector: selector,
-          scope: '.post',
-          overwrite: false,
-          prefix: 'toc'
-      });
-
-      var heading = document.createElement("H2");
-      var heading_text = document.createTextNode("Table of Contents");
-      heading.appendChild(heading_text);
-
-      container.appendChild(heading);
-      container.appendChild(toc);
     }
   </script>
 </head>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -159,4 +159,8 @@ aside#toc {
     top: 0.9em;
     position: relative;
   }
+
+  aside#toc.coarse li ol {
+    display: none;
+  }
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -130,9 +130,9 @@ aside#toc {
     line-height: 1.1;
   }
 
-  aside#toc:before {
-    content: "Table of Contents";
-    font-weight: bold;
+  aside#toc h2 {
+    font-size: 110%;
+    margin-bottom: .2rem;
   }
 
   aside#toc ol {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -122,12 +122,12 @@ aside#toc {
 @media (min-width: 80rem) {
   aside#toc {
     display: block;
-    width: 15em;
+    width: 12rem;
     position: fixed;
-    left:1rem;
     top: 4rem;
+    margin-left: -15rem;
     font-size: 90%;
-    line-height: 1.1;
+    line-height: 1.2;
   }
 
   aside#toc h2 {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -128,6 +128,12 @@ aside#toc {
     margin-left: -15rem;
     font-size: 90%;
     line-height: 1.2;
+    opacity: .2;
+    transition: opacity .5s;
+  }
+
+  aside#toc:hover {
+    opacity: 1;
   }
 
   aside#toc h2 {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -114,3 +114,43 @@ sup, sub {
 a.anchorjs-link:hover {
     text-decoration: none;
 }
+
+aside#toc {
+  display: none;
+}
+
+@media (min-width: 80rem) {
+  aside#toc {
+    display: block;
+    width: 15em;
+    position: fixed;
+    left:1rem;
+    top: 4rem;
+    font-size: 90%;
+    line-height: 1.1;
+  }
+
+  aside#toc:before {
+    content: "Table of Contents";
+    font-weight: bold;
+  }
+
+  aside#toc ol {
+    margin: 0 0 .2rem 0;
+    padding: 0 0 0 1rem;
+    list-style:none;
+  }
+
+  aside#toc ol li:before {
+    content: "";
+    border-color: transparent #008eef;
+    border-style: solid;
+    border-width: 0.35em 0 0.35em 0.45em;
+    display: block;
+    height: 0;
+    width: 0;
+    left: -1em;
+    top: 0.9em;
+    position: relative;
+  }
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,22 @@
+window.onload = function() {
+  var container = document.querySelector('#toc');
+
+  var selector = "h2";
+  if (container.className.split(" ").indexOf("coarse") == -1) {
+    selector += ",h3";
+  }
+
+  var toc = initTOC({
+      selector: selector,
+      scope: '.post',
+      overwrite: false,
+      prefix: 'toc'
+  });
+
+  var heading = document.createElement("H2");
+  var heading_text = document.createTextNode("Table of Contents");
+  heading.appendChild(heading_text);
+
+  container.appendChild(heading);
+  container.appendChild(toc);
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,17 +1,19 @@
 window.onload = function() {
   var container = document.querySelector('#toc');
 
-  var toc = initTOC({
-      selector: 'h2, h3',
-      scope: '.post',
-      overwrite: false,
-      prefix: 'toc'
-  });
+  if (container != null) {
+    var toc = initTOC({
+        selector: 'h2, h3',
+        scope: '.post',
+        overwrite: false,
+        prefix: 'toc'
+    });
 
-  var heading = document.createElement("H2");
-  var heading_text = document.createTextNode("Table of Contents");
-  heading.appendChild(heading_text);
+    var heading = document.createElement("H2");
+    var heading_text = document.createTextNode("Table of Contents");
+    heading.appendChild(heading_text);
 
-  container.appendChild(heading);
-  container.appendChild(toc);
+    container.appendChild(heading);
+    container.appendChild(toc);
+  }
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,13 +1,8 @@
 window.onload = function() {
   var container = document.querySelector('#toc');
 
-  var selector = "h2";
-  if (container.className.split(" ").indexOf("coarse") == -1) {
-    selector += ",h3";
-  }
-
   var toc = initTOC({
-      selector: selector,
+      selector: 'h2, h3',
       scope: '.post',
       overwrite: false,
       prefix: 'toc'

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -15,5 +15,26 @@ window.onload = function() {
 
     container.appendChild(heading);
     container.appendChild(toc);
+
+    resize_toc(container);
   }
+}
+
+function resize_toc(container) {
+  var containerHeight = container.clientHeight;
+
+  var resize = function() {
+    if (containerHeight > document.documentElement.clientHeight - 100) {
+      container.classList.add('coarse');
+    } else {
+      container.classList.remove('coarse');
+    }
+  };
+  resize();
+
+  var resizeId;
+  window.onresize = function() {
+    clearTimeout(resizeId);
+    resizeId = setTimeout(resize, 300);
+  };
 }

--- a/static/js/toc.min.js
+++ b/static/js/toc.min.js
@@ -1,0 +1,9 @@
+/*!
+ * jQuery-TOC
+ * Table of Contents Generator Plugin for (non-)jQuery
+ *
+ * @author Dolphin Wood <dolphin.w.e@gmail.com>
+ * @version 0.0.5
+ * Copyright 2015. MIT licensed.
+ */
+!function(e){"use strict";var t=function(e,t){for(var n in t)t.hasOwnProperty(n)&&t[n]&&(e[n]=t[n]);return e},n=function(e,t){var n=[],r=document.querySelectorAll(t);return Array.prototype.forEach.call(r,function(t){var r=t.querySelectorAll(e);n=n.concat(Array.prototype.slice.call(r))}),n},r=function(e){if("string"!=typeof e)return 0;var t=e.match(/\d/g);return t?Math.min.apply(null,t):1},o=function(e,t){for(;t--;)e=e.appendChild(document.createElement("ol")),t&&(e=e.appendChild(document.createElement("li")));return e},c=function(e,t){for(;t--;)e=e.parentElement;return e},i=function(e,t){return function(n,r,o){var c=n.textContent,i=t+"-"+o;r.textContent=c;var a=e?i:n.id||i;a=encodeURIComponent(a),n.id=a,r.href="#"+a}},a=function(e){var t=e.selector,a=e.scope,u=document.createElement("ol"),l=u,f=null,h=i(e.overwrite,e.prefix);return n(t,a).reduce(function(e,t,n){var i=r(t.tagName),a=i-e;a>0&&(l=o(f,a)),0>a&&(l=c(l,2*-a)),l=l||u;var p=document.createElement("li"),d=document.createElement("a");return h(t,d,n),l.appendChild(p).appendChild(d),f=p,i},r(t)),u},u=function(e){var n={selector:"h1, h2, h3, h4, h5, h6",scope:"body",overwrite:!1,prefix:"toc"};e=t(n,e);var r=e.selector;if("string"!=typeof r)throw new TypeError("selector must be a string");if(!r.match(/^(?:h[1-6],?\s*)+$/g))throw new TypeError("selector must contains only h1-6");var o=location.hash;return o&&setTimeout(function(){location.hash="",location.hash=o},0),a(e)};"function"==typeof define&&define.amd?define(function(){return u}):e.initTOC=u}(window);


### PR DESCRIPTION
# Option 1

The ToC is displayed through javascript on the left side when the display is large enough:

--

![screenshot at 2016-07-17 16 46 46](https://cloud.githubusercontent.com/assets/1131315/16901242/1b01800a-4c3e-11e6-82bd-00691d01b1db.png)

---

The ToC position is fixed so that it doesn't scroll with the rest of the page and remains always at the same place:

--

![screenshot at 2016-07-17 16 48 35](https://cloud.githubusercontent.com/assets/1131315/16901249/512c4d86-4c3e-11e6-80fa-79d972092b66.png)

---

On smaller displays, the ToC is hidden via `display: none`.

# Option 2
Put it on the right side and use absolute instead of fixed positioning:

--

![screenshot at 2016-07-17 19 22 14](https://cloud.githubusercontent.com/assets/1131315/16902041/d4cf10c8-4c53-11e6-9957-a03701b7bc1c.png)

---

![screenshot at 2016-07-17 19 22 35](https://cloud.githubusercontent.com/assets/1131315/16902043/da2cd2c6-4c53-11e6-9dbc-ac9310c15519.png)

# Option 3
Put it before the text, so that it is displayed on all devices.

# Unresolved Questions
- Other options?
- Is a ToC too much visual clutter?
- Design improvements?
- Should we also display it on smaller displays?
- Fade the ToC out until the mouse hovers it again?