### PR TITLE
Fix hex constant

### DIFF
--- a/blog/post/2015-08-18-multiboot-kernel.md
+++ b/blog/post/2015-08-18-multiboot-kernel.md
@@ -110,7 +110,7 @@ There are some new commands:
 - `global` exports a label (makes it public). As `start` will be the entry point of our kernel, it needs to be public.
 - the `.text` section is the default section for executable code
 - `bits 32` specifies that the following lines are 32-bit instructions. It's needed because the CPU is still in [Protected mode] when GRUB starts our kernel. When we switch to [Long mode] in the [next post] we can use `bits 64` (64-bit instructions).
-- the `mov dword` instruction moves the 32bit constant `0x2f4f2f4b` to the memory at address `b8000` (it prints `OK` to the screen, an explanation follows in the next posts)
+- the `mov dword` instruction moves the 32bit constant `0x2f4b2f4f` to the memory at address `b8000` (it prints `OK` to the screen, an explanation follows in the next posts)
 - `hlt` is the halt instruction and causes the CPU to stop
 
 Through assembling, viewing and disassembling we can see the CPU [Opcodes] in action:


### PR DESCRIPTION
`2f4f` and `2f4b` switches places in one places where it's mentioned, I assume this was a typo since all the others looked this way :)
Edit: And, now that I've managed to build the thing (thanks by the way), because `0x2f4b2f4f` is `OK` while the reversed is `KO`