### PR TITLE
Add rsi to the clobber list

### DIFF
--- a/blog/post/2016-08-03-better-exception-messages.md
+++ b/blog/post/2016-08-03-better-exception-messages.md
@@ -509,7 +509,7 @@ macro_rules! handler_with_error_code {
                       call $0"
                       :: "i"($name as extern "C" fn(
                           *const ExceptionStackFrame, u64) -> !)
-                      : "rdi" : "intel");
+                      : "rdi,rsi" : "intel");
                 ::core::intrinsics::unreachable();
             }
         }


### PR DESCRIPTION
In the second macro (handler_with_error_code), we pop the error code into rsi, this means we are changing the value of rsi in the assembly block, so we should add it to the clobbers.

I am quite new to this, so please close this request if I am completely wrong.

(Side question: An other thing I came across while trying to figure out if this was correct, is that every documentation says you should add curly brackets around register names, can someone tell me why this is not done here?)