### PR TITLE
Fix typo (therefor -> therefore)

### DIFF
--- a/blog/post/2015-12-09-page-tables.md
+++ b/blog/post/2015-12-09-page-tables.md
@@ -600,7 +600,7 @@ pub fn map_to<A>(page: Page, frame: Frame, flags: EntryFlags,
 ```
 We add an reexport for all `entry` types since they are required to call the function. We assert that the page is unmapped and always set the present flag (since it wouldn't make sense to map a page without setting it).
 
-The `Table::next_table_create` method doesn't exist yet. It should return the next table if it exists, or create a new one. Therefore we need the `FrameAllocator` from the [previous post] and the `Table::zero` method:
+The `Table::next_table_create` method doesn't exist yet. It should return the next table if it exists, or create a new one. For the implementation we need the FrameAllocator from the [previous post] and the `Table::zero` method:
 
 ```rust
 use memory::FrameAllocator;

--- a/blog/post/2015-12-09-page-tables.md
+++ b/blog/post/2015-12-09-page-tables.md
@@ -600,7 +600,7 @@ pub fn map_to<A>(page: Page, frame: Frame, flags: EntryFlags,
 ```
 We add an reexport for all `entry` types since they are required to call the function. We assert that the page is unmapped and always set the present flag (since it wouldn't make sense to map a page without setting it).
 
-The `Table::next_table_create` method doesn't exist yet. It should return the next table if it exists, or create a new one. For the implementation we need the FrameAllocator from the [previous post] and the `Table::zero` method:
+The `Table::next_table_create` method doesn't exist yet. It should return the next table if it exists, or create a new one. For the implementation we need the `FrameAllocator` from the [previous post] and the `Table::zero` method:
 
 ```rust
 use memory::FrameAllocator;

--- a/blog/post/2015-12-09-page-tables.md
+++ b/blog/post/2015-12-09-page-tables.md
@@ -600,7 +600,7 @@ pub fn map_to<A>(page: Page, frame: Frame, flags: EntryFlags,
 ```
 We add an reexport for all `entry` types since they are required to call the function. We assert that the page is unmapped and always set the present flag (since it wouldn't make sense to map a page without setting it).
 
-The `Table::next_table_create` method doesn't exist yet. It should return the next table if it exists, or create a new one. Therefor we need the `FrameAllocator` from the [previous post] and the `Table::zero` method:
+The `Table::next_table_create` method doesn't exist yet. It should return the next table if it exists, or create a new one. Therefore we need the `FrameAllocator` from the [previous post] and the `Table::zero` method:
 
 ```rust
 use memory::FrameAllocator;

--- a/blog/post/2016-01-01-remap-the-kernel.md
+++ b/blog/post/2016-01-01-remap-the-kernel.md
@@ -4,7 +4,7 @@ date = "2016-01-01"
 updated = "2016-03-06"
 +++
 
-In this post we will create a new page table to map the kernel sections correctly. Therefor we will extend the paging module to support modifications of _inactive_ page tables as well. Then we will switch to the new table and secure our kernel stack by creating a guard page.
+In this post we will create a new page table to map the kernel sections correctly. Therefore we will extend the paging module to support modifications of _inactive_ page tables as well. Then we will switch to the new table and secure our kernel stack by creating a guard page.
 
 <!--more--><aside id="toc"></aside>
 


### PR DESCRIPTION
I am not a native English speaker, so I am not 100% sure this is correct, but from the information I found on https://www.translegal.com/legal-english-lessons/therefore-vs-therefor , it looks like in this case, the word "therefore" is correct.