### PR TITLE
Fix various typos

### DIFF
--- a/blog/post/2015-08-25-entering-longmode.md
+++ b/blog/post/2015-08-25-entering-longmode.md
@@ -184,11 +184,11 @@ If you look at the assembly above, you'll probably notice that we call `cpuid` t
 We just call these check functions right after start:
 
 ```nasm
-global _start
+global start
 
 section .text
 bits 32
-_start:
+start:
     mov esp, stack_top
 
     call check_multiboot

--- a/blog/post/2015-09-02-set-up-rust.md
+++ b/blog/post/2015-09-02-set-up-rust.md
@@ -1,7 +1,7 @@
 +++
 title = "Set Up Rust"
 date = "2015-09-02"
-updated = "2015-05-29"
+updated = "2016-05-29"
 aliases = [
     "/2015/09/02/setup-rust/",
     "/setup-rust.html",

--- a/blog/post/2015-12-09-page-tables.md
+++ b/blog/post/2015-12-09-page-tables.md
@@ -881,7 +881,7 @@ To test the `unmap` function, we unmap the test page so that it translates to `N
 page_table.unmap(Page::containing_address(addr), allocator);
 println!("None = {:?}", page_table.translate(addr));
 ```
-It causes a panic since we call the unimplemented `deallocate_frame` method in `unwrap`. If we comment this call out, it works without problems. But there is some bug in this function nevertheless.
+It causes a panic since we call the unimplemented `deallocate_frame` method in `unmap`. If we comment this call out, it works without problems. But there is some bug in this function nevertheless.
 
 Let's read something from the mapped page (of course before we unmap it again):
 

--- a/blog/post/2015-12-09-page-tables.md
+++ b/blog/post/2015-12-09-page-tables.md
@@ -598,7 +598,7 @@ pub fn map_to<A>(page: Page, frame: Frame, flags: EntryFlags,
     p1[page.p1_index()].set(frame, flags | PRESENT);
 }
 ```
-We add an reexport for all `entry` types since they are required to call the function. We assert that the page is unmapped and always set the present flag (since it wouldn't make sense to map a page without setting it).
+We add an re-export for all `entry` types since they are required to call the function. We assert that the page is unmapped and always set the present flag (since it wouldn't make sense to map a page without setting it).
 
 The `Table::next_table_create` method doesn't exist yet. It should return the next table if it exists, or create a new one. For the implementation we need the `FrameAllocator` from the [previous post] and the `Table::zero` method:
 
@@ -781,7 +781,7 @@ pub fn test_paging<A>(allocator: &mut A)
     // test it
 }
 ```
-We borrow the frame allocator since we will need it for the mapping functions. To be able to call that function from main, we need to reexport it in `memory/mod.rs`:
+We borrow the frame allocator since we will need it for the mapping functions. To be able to call that function from main, we need to re-export it in `memory/mod.rs`:
 
 ```rust
 // in memory/mod.rs

--- a/blog/post/2016-01-01-remap-the-kernel.md
+++ b/blog/post/2016-01-01-remap-the-kernel.md
@@ -707,7 +707,7 @@ SECTIONS {
 Instead of page aligning the `.multiboot_header` section, we merge it into the `.rodata` section. That way, we don't waste a whole page for the few bytes of the Multiboot header. We could merge it into any section, but `.rodata` fits best because it has the same flags (neither writable nor executable). The Multiboot header still needs to be at the beginning of the file, so `.rodata` must be our first section now.
 
 ### Testing it
-Time to test it! We reexport the `remap_the_kernel` function from the memory module and call it from `rust_main`:
+Time to test it! We re-export the `remap_the_kernel` function from the memory module and call it from `rust_main`:
 
 ```rust
 // in src/memory/mod.rs


### PR DESCRIPTION
While going through the posts, I found some small typos:

1. In `boot.asm`, the `start` function was `_start` in one listing,
2. The `Set up Rust` post had an incorrect year of last update (2015 instead of 2016),
3. `unwrap` instead of `unmap` in `Modifying Page Tables`,
4. Changed `reexport` to `re-export` in some cases.