### PR TITLE
Fix atom feed

### DIFF
--- a/ci/travis-blog-update.sh
+++ b/ci/travis-blog-update.sh
@@ -26,8 +26,6 @@ git config user.email "travis-update-bot@phil-opp.com"
 # update blog
 rm -r *
 cp -r ../public/. .
-rm atom.xml # remove feed that includes all content types
-mv post/atom.xml . # use post feed as main feed
 rm -r post post.html page page.html additional-resource additional-resource.html # remove per-category pages/feeds
 
 # commit

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,0 +1,24 @@
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ .Site.Title }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    <atom:link href="{{.URL}}" rel="self" type="application/rss+xml" />
+    {{ range first 15 (where .Data.Pages "Section" "post") }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Content | html }}</description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
This PR adds a template file for the main rss feed. Thus we can avoid the hack that we've used before (copy the default feed for the `post` category to the root).

Fixes #211 