### PR TITLE
Exceptions: Take the ExceptionStackFrame per reference

### DIFF
--- a/src/interrupts/mod.rs
+++ b/src/interrupts/mod.rs
@@ -49,7 +49,7 @@ macro_rules! handler {
                       add rdi, 9*8 // calculate exception stack frame pointer
                       call $0"
                       :: "i"($name as extern "C" fn(
-                          *const ExceptionStackFrame))
+                          &ExceptionStackFrame))
                       : "rdi" : "intel");
 
                 restore_scratch_registers!();
@@ -74,7 +74,7 @@ macro_rules! handler_with_error_code {
                       call $0
                       add rsp, 8 // undo stack pointer alignment
                       " :: "i"($name as extern "C" fn(
-                          *const ExceptionStackFrame, u64))
+                          &ExceptionStackFrame, u64))
                       : "rdi","rsi" : "intel");
                 restore_scratch_registers!();
                 asm!("add rsp, 8 // pop error code
@@ -113,24 +113,21 @@ struct ExceptionStackFrame {
     stack_segment: u64,
 }
 
-extern "C" fn divide_by_zero_handler(stack_frame: *const ExceptionStackFrame) {
-    let stack_frame = unsafe { &*stack_frame };
+extern "C" fn divide_by_zero_handler(stack_frame: &ExceptionStackFrame) {
     println!("\nEXCEPTION: DIVIDE BY ZERO\n{:#?}", stack_frame);
     loop {}
 }
 
-extern "C" fn breakpoint_handler(stack_frame: *const ExceptionStackFrame) {
-    let stack_frame = unsafe { &*stack_frame };
+extern "C" fn breakpoint_handler(stack_frame: &ExceptionStackFrame) {
     println!("\nEXCEPTION: BREAKPOINT at {:#x}\n{:#?}",
              stack_frame.instruction_pointer,
              stack_frame);
 }
 
-extern "C" fn invalid_opcode_handler(stack_frame: *const ExceptionStackFrame) {
-    let stack_frame = unsafe { &*stack_frame };
+extern "C" fn invalid_opcode_handler(stack_frame: &ExceptionStackFrame) {
     println!("\nEXCEPTION: INVALID OPCODE at {:#x}\n{:#?}",
              stack_frame.instruction_pointer,
-             *stack_frame);
+             stack_frame);
     loop {}
 }
 
@@ -144,8 +141,7 @@ bitflags! {
     }
 }
 
-extern "C" fn page_fault_handler(stack_frame: *const ExceptionStackFrame, error_code: u64) {
-    let stack_frame = unsafe { &*stack_frame };
+extern "C" fn page_fault_handler(stack_frame: &ExceptionStackFrame, error_code: u64) {
     use x86::controlregs;
     println!("\nEXCEPTION: PAGE FAULT while accessing {:#x}\nerror code: \
                                   {:?}\n{:#?}",


### PR DESCRIPTION
This PR changes the type of exception handler functions. Instead of a `*const ExceptionStackFrame`, they now take a `&ExceptionStackFrame` as argument. The reason is that they require the pointer to be valid (they used to blindly derefence the raw pointer). So the old implementation was unsound, since the functions used to violate memory safety when an invalid pointer is passed.

A consequence of this change is that we should no longer modify the exception stack frame (since we have an immutable reference to it). And transmuting a `&` to a `&mut` is undefined behavior. So the last section of _Returning from Exceptions_ (_“Page Faults as Breakpoints”_) becomes even more hacky. Therefore, this PR removes that section. Instead, we now test the iretq logic by entering an endless loop between the exception handler and the instruction accessing 0xdeadbeaf.