### PR TITLE
Add a Xargo.toml for xargo 0.3.0 and update the corresponding post

### DIFF
--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,0 +1,2 @@
+[target.x86_64-blog_os.dependencies]
+collections = {}


### PR DESCRIPTION
Xargo 0.3.0 was just released: https://users.rust-lang.org/t/xargo-v0-3-0-released-build-your-own-std/8571

By default it compiles only `core` now. However, we also need `alloc` and `collections`. We can enable them by creating a file named `Xargo.toml` with the following content:

```toml
[target.x86_64-blog_os.dependencies]
collections = {}
```

Fixes #271 