### PR TITLE
Remove the data segment from assembly 64-bit GDT

### DIFF
--- a/src/arch/x86_64/boot.asm
+++ b/src/arch/x86_64/boot.asm
@@ -29,12 +29,6 @@ start:
     ; load the 64-bit GDT
     lgdt [gdt64.pointer]
 
-    ; update selectors
-    mov ax, gdt64.data
-    mov ss, ax
-    mov ds, ax
-    mov es, ax
-
     jmp gdt64.code:long_mode_start
 
 set_up_page_tables:
@@ -203,8 +197,6 @@ gdt64:
     dq 0 ; zero entry
 .code: equ $ - gdt64 ; new
     dq (1<<44) | (1<<47) | (1<<41) | (1<<43) | (1<<53) ; code segment
-.data: equ $ - gdt64 ; new
-    dq (1<<44) | (1<<47) | (1<<41) ; data segment
 .pointer:
     dw $ - gdt64 - 1
     dq gdt64

--- a/src/arch/x86_64/long_mode_init.asm
+++ b/src/arch/x86_64/long_mode_init.asm
@@ -13,6 +13,14 @@ extern rust_main
 section .text
 bits 64
 long_mode_start:
+    ; load 0 into all data segment registers
+    mov ax, 0
+    mov ss, ax
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+
     ; call rust main (with multiboot pointer in rdi)
     call rust_main
 .os_returned:


### PR DESCRIPTION
The Intel and AMD manuals state that no data segment is needed in 64-bit mode. However, the `iretq` instruction expects a valid data segment selector or a null selector in the `ss` register.

This PR removes all ignored fields from the GDT structure overview in _Entering Long Mode_. It also removes the data segment from the assembly 64-bit GDT and no longer reloads the data segment registers before jumping to 64-bit mode. Instead, we reload them with null selectors after we're in 64-bit mode.

Fixes #273
Fixes #277