### PR TITLE
Expand stack to 16k

### DIFF
--- a/src/arch/x86_64/boot.asm
+++ b/src/arch/x86_64/boot.asm
@@ -189,7 +189,7 @@ p3_table:
 p2_table:
     resb 4096
 stack_bottom:
-    resb 4096 * 2
+    resb 4096 * 4
 stack_top:
 
 section .rodata


### PR DESCRIPTION
Since we started using the IDT struct specified on the x86_64 crate, we
need more space for all the 256 entries and not only for the first 16
(or 32?) entries as on the old IDT type.

### Additional information

- This fix #294
- This change must be included on the new planned blog post #292