### PR TITLE
Link to new `post_X` tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,29 @@ This repository contains the source code for the _Writing an OS in Rust_ series 
 
 ## Bare Bones
 - [A Minimal x86 Kernel](http://os.phil-opp.com/multiboot-kernel.html)
-      ([source code](https://github.com/phil-opp/blog_os/tree/multiboot_bootstrap))
+      ([source code](https://github.com/phil-opp/blog_os/tree/post_1))
 - [Entering Long Mode](http://os.phil-opp.com/entering-longmode.html)
-      ([source code](https://github.com/phil-opp/blog_os/tree/entering_longmode))
+      ([source code](https://github.com/phil-opp/blog_os/tree/post_2))
 - [Set Up Rust](http://os.phil-opp.com/set-up-rust.html)
-      ([source code](https://github.com/phil-opp/blog_os/tree/set_up_rust))
+      ([source code](https://github.com/phil-opp/blog_os/tree/post_3))
 - [Printing to Screen](http://os.phil-opp.com/printing-to-screen.html)
-      ([source code](https://github.com/phil-opp/blog_os/tree/printing_to_screen))
+      ([source code](https://github.com/phil-opp/blog_os/tree/post_4))
 
 ## Memory Management
 - [Allocating Frames](http://os.phil-opp.com/allocating-frames.html)
-      ([source code](https://github.com/phil-opp/blog_os/tree/allocating_frames))
+      ([source code](https://github.com/phil-opp/blog_os/tree/post_5))
 - [Page Tables](http://os.phil-opp.com/modifying-page-tables.html)
-      ([source code](https://github.com/phil-opp/blog_os/tree/page_tables))
+      ([source code](https://github.com/phil-opp/blog_os/tree/post_6))
 - [Remap the Kernel](http://os.phil-opp.com/remap-the-kernel.html)
-      ([source code](https://github.com/phil-opp/blog_os/tree/remap_the_kernel))
+      ([source code](https://github.com/phil-opp/blog_os/tree/post_7))
 - [Kernel Heap](http://os.phil-opp.com/kernel-heap.html)
-      ([source code](https://github.com/phil-opp/blog_os/tree/kernel_heap))
+      ([source code](https://github.com/phil-opp/blog_os/tree/post_8))
 
 ## Exceptions
 - [Handling Exceptions](http://os.phil-opp.com/handling-exceptions.html)
-      ([source code](https://github.com/phil-opp/blog_os/tree/handling_exceptions))
+      ([source code](https://github.com/phil-opp/blog_os/tree/post_9))
 - [Double Faults](http://os.phil-opp.com/double-faults.html)
-      ([source code](https://github.com/phil-opp/blog_os/tree/double_faults))
+      ([source code](https://github.com/phil-opp/blog_os/tree/post_10))
 
 ## Additional Resources
 - [Cross Compile Binutils](http://os.phil-opp.com/cross-compile-binutils.html)

--- a/blog/content/post/04-printing-to-screen.md
+++ b/blog/content/post/04-printing-to-screen.md
@@ -20,7 +20,7 @@ In the [previous post] we switched from assembly to [Rust], a systems programmin
 This post uses recent unstable features, so you need an up-to-date nighly compiler. If you have any questions, problems, or suggestions please [file an issue] or create a comment at the bottom. The code from this post is also available on [Github][code repository].
 
 [file an issue]: https://github.com/phil-opp/blog_os/issues
-[code repository]: https://github.com/phil-opp/blog_os/tree/printing_to_screen
+[code repository]: https://github.com/phil-opp/blog_os/tree/post_4
 
 ## The VGA Text Buffer
 The text buffer starts at physical address `0xb8000` and contains the characters displayed on screen. It has 25 rows and 80 columns. Each screen character has the following format:

--- a/blog/content/post/05-allocating-frames.md
+++ b/blog/content/post/05-allocating-frames.md
@@ -9,7 +9,7 @@ In this post we create an allocator that provides free physical frames for a fut
 
 The full source code is available on [Github][source repo]. Feel free to open issues there if you have any problems or improvements. You can also leave a comment at the bottom.
 
-[source repo]: https://github.com/phil-opp/blog_os/tree/allocating_frames
+[source repo]: https://github.com/phil-opp/blog_os/tree/post_5
 
 ## Preparation
 We still have a really tiny stack of 64 bytes, which won't suffice for this post. So we increase it to 16kB (four pages) in `boot.asm`:

--- a/blog/content/post/06-page-tables.md
+++ b/blog/content/post/06-page-tables.md
@@ -10,7 +10,7 @@ In this post we will create a paging module, which allows us to access and modif
 
 You can find the source code and this post itself on [Github][source repository]. Please file an issue there if you have any problems or improvement suggestions. There is also a comment section at the end of this page. Note that this post requires a current Rust nightly.
 
-[source repository]: https://github.com/phil-opp/blog_os/tree/page_tables
+[source repository]: https://github.com/phil-opp/blog_os/tree/post_6
 
 ## Paging
 _Paging_ is a memory management scheme that separates virtual and physical memory. The address space is split into equal sized _pages_ and _page tables_ specify which virtual page points to which physical frame. For an extensive paging introduction take a look at the paging chapter ([PDF][paging chapter]) of the [Three Easy Pieces] OS book.

--- a/blog/content/post/07-remap-the-kernel.md
+++ b/blog/content/post/07-remap-the-kernel.md
@@ -10,7 +10,7 @@ In this post we will create a new page table to map the kernel sections correctl
 
 As always, you can find the source code on [Github]. Don't hesitate to file issues there if you have any problems or improvement suggestions. There is also a comment section at the end of this page. Note that this post requires a current Rust nightly.
 
-[Github]: https://github.com/phil-opp/blog_os/tree/remap_the_kernel
+[Github]: https://github.com/phil-opp/blog_os/tree/post_7
 
 ## Motivation
 

--- a/blog/content/post/08-kernel-heap.md
+++ b/blog/content/post/08-kernel-heap.md
@@ -14,7 +14,7 @@ In the previous posts we have created a [frame allocator] and a [page table modu
 
 As always, you can find the complete source code on [Github]. Please file [issues] for any problems, questions, or improvement suggestions. There is also a comment section at the end of this page.
 
-[Github]: https://github.com/phil-opp/blog_os/tree/kernel_heap
+[Github]: https://github.com/phil-opp/blog_os/tree/post_8
 [issues]: https://github.com/phil-opp/blog_os/issues
 
 ## Introduction

--- a/blog/content/post/09-handling-exceptions.md
+++ b/blog/content/post/09-handling-exceptions.md
@@ -11,7 +11,7 @@ In this post, we start exploring CPU exceptions. Exceptions occur in various err
 
 As always, the complete source code is available on [Github]. Please file [issues] for any problems, questions, or improvement suggestions. There is also a comment section at the end of this page.
 
-[Github]: https://github.com/phil-opp/blog_os/tree/handling_exceptions
+[Github]: https://github.com/phil-opp/blog_os/tree/post_9
 [issues]: https://github.com/phil-opp/blog_os/issues
 
 ## Exceptions

--- a/blog/content/post/10-double-faults.md
+++ b/blog/content/post/10-double-faults.md
@@ -9,7 +9,7 @@ In this post we explore double faults in detail. We also set up an _Interrupt St
 
 As always, the complete source code is available on [Github]. Please file [issues] for any problems, questions, or improvement suggestions. There is also a [gitter chat] and a [comment section] at the end of this page.
 
-[Github]: https://github.com/phil-opp/blog_os/tree/double_faults
+[Github]: https://github.com/phil-opp/blog_os/tree/post_10
 [issues]: https://github.com/phil-opp/blog_os/issues
 [gitter chat]: https://gitter.im/phil-opp/blog_os
 [comment section]: #disqus_thread


### PR DESCRIPTION
I followed the posts step-by-step from the very beginning again and fixed various things along the way (#311, #317, #318, #319). The resulting code can be found in the `post_1`, `post_2`, etc. tags. Instead of branching off the master branch, these new tags are completely unrelated to any other branch (i.e. they form a completely separate history).

This makes our backporting process much easier. With the previous system, we needed to cherry-pick a fix to all affected tags (and resolve the merge conflicts). Now we can just cherry-pick the fix once and rebase all following tags on their predecessor (e.g. `post_3` on `post_2`, `post_4` on `post_3`, and so on). The new `post_X` names make it easy to automate this rebasing process (rebase `post_N` on `post_{N-1}`).

This PR also fixes #303.

I plan to delete the old tags (e.g. `entering_longmode`, `set_up_rust`, etc.) in the next few days after I verified that all tag links have been updated. I hope that there are no external links to these tags…