### PR TITLE
Unique::get/get_mut were renamed to as_ref/as_mut

### DIFF
--- a/blog/content/post/04-printing-to-screen.md
+++ b/blog/content/post/04-printing-to-screen.md
@@ -177,7 +177,7 @@ impl Writer {
     }
 
     fn buffer(&mut self) -> &mut Buffer {
-        unsafe{ self.buffer.get_mut() }
+        unsafe{ self.buffer.as_mut() }
     }
 
     fn new_line(&mut self) {/* TODO */}
@@ -189,8 +189,8 @@ If the byte is the [newline] byte `\n`, the writer does not print anything. Inst
 
 When printing a byte, the writer checks if the current line is full. In that case, a `new_line` call is required before to wrap the line. Then it writes a new `ScreenChar` to the buffer at the current position. Finally, the current column position is advanced.
 
-The `buffer()` auxiliary method converts the raw pointer in the `buffer` field into a safe mutable buffer reference. The unsafe block is needed because the [get_mut()] method of `Unique` is unsafe. But our `buffer()` method itself isn't marked as unsafe, so it must not introduce any unsafety (e.g. cause segfaults). To guarantee that, it's very important that the `buffer` field always points to a valid `Buffer`. It's like a contract that we must stand to every time we create a `Writer`. To ensure that it's not possible to create an invalid `Writer` from outside of the module, the struct must have at least one private field and public creation functions are not allowed either.
-[get_mut()]: https://doc.rust-lang.org/nightly/core/ptr/struct.Unique.html#method.get_mut
+The `buffer()` auxiliary method converts the raw pointer in the `buffer` field into a safe mutable buffer reference. The unsafe block is needed because the [as_mut()] method of `Unique` is unsafe. But our `buffer()` method itself isn't marked as unsafe, so it must not introduce any unsafety (e.g. cause segfaults). To guarantee that, it's very important that the `buffer` field always points to a valid `Buffer`. It's like a contract that we must stand to every time we create a `Writer`. To ensure that it's not possible to create an invalid `Writer` from outside of the module, the struct must have at least one private field and public creation functions are not allowed either.
+[as_mut()]: https://doc.rust-lang.org/nightly/core/ptr/struct.Unique.html#method.as_mut
 
 ### Cannot Move out of Borrowed Content
 When we try to compile it, we get the following error:

--- a/blog/content/post/06-page-tables.md
+++ b/blog/content/post/06-page-tables.md
@@ -670,11 +670,11 @@ We add some methods to get P4 references:
 
 ```rust
 fn p4(&self) -> &Table<Level4> {
-    unsafe { self.p4.get() }
+    unsafe { self.p4.as_ref() }
 }
 
 fn p4_mut(&mut self) -> &mut Table<Level4> {
-    unsafe { self.p4.get_mut() }
+    unsafe { self.p4.as_mut() }
 }
 ```
 

--- a/src/memory/paging/mapper.rs
+++ b/src/memory/paging/mapper.rs
@@ -23,11 +23,11 @@ impl Mapper {
     }
 
     pub fn p4(&self) -> &Table<Level4> {
-        unsafe { self.p4.get() }
+        unsafe { self.p4.as_ref() }
     }
 
     pub fn p4_mut(&mut self) -> &mut Table<Level4> {
-        unsafe { self.p4.get_mut() }
+        unsafe { self.p4.as_mut() }
     }
 
     pub fn translate(&self, virtual_address: VirtualAddress) -> Option<PhysicalAddress> {

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -95,7 +95,7 @@ impl Writer {
     }
 
     fn buffer(&mut self) -> &mut Buffer {
-        unsafe { self.buffer.get_mut() }
+        unsafe { self.buffer.as_mut() }
     }
 
     fn new_line(&mut self) {


### PR DESCRIPTION
Fixes #324 