### PR TITLE
Add new required target-c-int-width field to target json

### DIFF
--- a/blog/content/extra/naked-exceptions/03-returning-from-exceptions/index.md
+++ b/blog/content/extra/naked-exceptions/03-returning-from-exceptions/index.md
@@ -506,6 +506,7 @@ A minimal target specification that describes the `x86_64-unknown-linux-gnu` tar
   "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
   "target-endian": "little",
   "target-pointer-width": "64",
+  "target-c-int-width": "32",
   "arch": "x86_64",
   "os": "none"
 }
@@ -527,6 +528,7 @@ In order to disable the multimedia extensions, we create a new target named `x86
   "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
   "target-endian": "little",
   "target-pointer-width": "64",
+  "target-c-int-width": "32",
   "arch": "x86_64",
   "os": "none",
   "features": "-mmx,-sse"

--- a/blog/content/posts/03-set-up-rust/index.md
+++ b/blog/content/posts/03-set-up-rust/index.md
@@ -98,6 +98,7 @@ Rust allows us to define [custom targets] through a JSON configuration file. A m
   "linker-flavor": "gcc",
   "target-endian": "little",
   "target-pointer-width": "64",
+  "target-c-int-width": "32",
   "arch": "x86_64",
   "os": "linux"
 }
@@ -132,6 +133,7 @@ For our target system, we define the following JSON configuration in a file name
   "linker-flavor": "gcc",
   "target-endian": "little",
   "target-pointer-width": "64",
+  "target-c-int-width": "32",
   "arch": "x86_64",
   "os": "none",
   "disable-redzone": true,
@@ -139,7 +141,7 @@ For our target system, we define the following JSON configuration in a file name
 }
 ```
 
-As `llvm-target` we use `x86_64-unknown-none`, which defines the `x86_64` architecture, an `unknown` vendor, and no operating system (`none`). The ABI doesn't matter for us, so we just leave it off. The `data-layout` field is just copied from the `x86_64-unknown-linux-gnu` target. We also use the same values for the `target-endian`, `target-pointer-width`, and `arch` fields. For the `os` field we choose `none`, since our kernel runs on bare metal.
+As `llvm-target` we use `x86_64-unknown-none`, which defines the `x86_64` architecture, an `unknown` vendor, and no operating system (`none`). The ABI doesn't matter for us, so we just leave it off. The `data-layout` field is just copied from the `x86_64-unknown-linux-gnu` target. We also use the same values for the `target-endian`, `target-pointer-width`, `target-c-int-width`, and `arch` fields. For the `os` field we choose `none`, since our kernel runs on bare metal.
 
 #### The Red Zone
 The [red zone] is an optimization of the [System V ABI] that allows functions to temporary use the 128 bytes below its stack frame without adjusting the stack pointer:

--- a/x86_64-blog_os.json
+++ b/x86_64-blog_os.json
@@ -4,6 +4,7 @@
   "linker-flavor": "gcc",
   "target-endian": "little",
   "target-pointer-width": "64",
+  "target-c-int-width": "32",
   "arch": "x86_64",
   "os": "none",
   "features": "-mmx,-sse,+soft-float",


### PR DESCRIPTION
There is a new required field for target configuration files: `target-c-int-width`. This field controls the size of the `argc` parameter and the return type of the native main function in `std` applications. (For `no_std` applications/libraries, we don't really need this field.) We set the value to 32, since it's the size of an `int` in most C calling conventions (including the 64-bit Linux calling convention).

See rust-lang/rust#44906 for more details.

Fixes #353 