### PR TITLE
Add new `const_unique_new` feature gate

### DIFF
--- a/blog/content/posts/04-printing-to-screen/index.md
+++ b/blog/content/posts/04-printing-to-screen/index.md
@@ -253,7 +253,9 @@ pub fn print_something() {
     writer.write_byte(b'H');
 }
 ```
-It just creates a new Writer that points to the VGA buffer at `0xb8000`. Then it writes the byte `b'H'` to it. The `b` prefix creates a [byte character], which represents an ASCII code point. When we call `vga_buffer::print_something` in main, a `H` should be printed in the _lower_ left corner of the screen in light green:
+It just creates a new Writer that points to the VGA buffer at `0xb8000`. To use the unstable `Unique::new_unchecked` function, we need to add the feature flag `#![feature(const_unique_new)]` to the top of our `src/lib.rs`.
+
+Then it writes the byte `b'H'` to it. The `b` prefix creates a [byte character], which represents an ASCII code point. When we call `vga_buffer::print_something` in main, a `H` should be printed in the _lower_ left corner of the screen in light green:
 
 [byte character]: https://doc.rust-lang.org/reference.html#characters-and-strings
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(asm)]
 #![feature(naked_functions)]
 #![feature(abi_x86_interrupt)]
+#![feature(const_unique_new)]
 #![no_std]
 
 extern crate rlibc;


### PR DESCRIPTION
The `const_fn` feature gates were individualized in https://github.com/rust-lang/rust/pull/43017 to allow stabilizing _uses_ of const fn without stabilizing const fn declarations.