### PR TITLE
A rewrite of the bump allocator to conform to the new API.

### DIFF
--- a/libs/bump_allocator/src/lib.rs
+++ b/libs/bump_allocator/src/lib.rs
@@ -21,44 +21,86 @@ extern crate alloc;
 extern crate spin;
 
 
-static HEAP: Mutex<Heap> = Mutex::new(Heap::new(0, 0));
-
-//Set up the heap
-pub unsafe fn init(offset: usize, size: usize) {
-    *HEAP.lock() = Heap::new(offset, size);
-}
-
-#[derive(Debug)]
-struct Heap {
-    start: usize,
-    end: usize,
-    next: usize,
+struct LockedHeap {
+    heap: Mutex<Heap>,
 }
 
 
-impl Heap {
-    /// Initialisation of the heap to use the 
-    /// range [start, start + size).
-    const fn new(start: usize, size: usize) -> Heap {
-        Heap {
-            start: start,
-            end: start + size,
-            next: start,
+#[global_allocator]
+static GLOBAL_ALLOC: LockedHeap = LockedHeap::empty();
+
+
+pub unsafe fn init(start: usize, size: usize) {
+    GLOBAL_ALLOC.init(start, size);
+}
+
+
+impl LockedHeap {
+    // Creates an empty heap. All allocate calls will return 'AllocErr`.
+    pub const fn empty() -> LockedHeap {
+        LockedHeap {
+            heap : Mutex::new(Heap::empty())
         }
+    }
+
+    unsafe fn init(&self, start: usize, size: usize)  {
+        self.heap.lock().init(start, size);
     }
 }
 
-pub struct Allocator;
+// The interface used for all allocation of heap structures. 
 
-unsafe impl<'a> Alloc for &'a Allocator {
+unsafe impl<'a> Alloc for &'a LockedHeap {
 
     unsafe fn alloc(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
-        let ref mut heap = HEAP.lock();
-        let alloc_start = align_up(heap.next, layout.align());
+        self.heap.lock().allocate(layout)
+    }
+
+    unsafe fn dealloc(&mut self, ptr: *mut u8, layout: Layout) {
+        self.heap.lock().dealloc(ptr, layout)
+    }
+}
+
+
+
+// A fixed size heap with a reference to the beginning of free space.
+
+pub struct Heap {
+    start: usize,
+    end: usize,
+    next:  usize,
+}
+
+impl Heap {
+    // Creates an empty heap. All allocate calls will return `AllocErr`.
+    pub const fn empty() -> Heap {
+        Heap {
+            start: 0,
+            end: 0,
+            next: 0,
+        }
+    }
+
+    // This is unsafe, the start address must be valid and the memory in
+    // the `[start, start + size)` range must not be used for anything
+    // else. This function is unsafe because it can cause undefined
+    // behavior if the given address or size are invalid.
+
+    unsafe fn init(&mut self, start: usize, size: usize) {
+        self.start = start;
+        self.end = start + size;
+        self.next = start;
+    }
+
+    // Allocates a chunk of the given size with the given alignment. Returns a pointer to the
+    // beginning of that chunk if it was successful, else it returns an AllocErr.
+
+    unsafe fn allocate(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
+        let alloc_start = align_up(self.next, layout.align());
         let alloc_end = alloc_start.saturating_add(layout.size());
 
-        if alloc_end <= heap.end {
-            heap.next =  alloc_end;
+        if alloc_end <= self.end {
+            self.next =  alloc_end;
             Ok(alloc_start as *mut u8)
         } else {
             Err(AllocErr::Exhausted{request: layout})
@@ -68,11 +110,11 @@ unsafe impl<'a> Alloc for &'a Allocator {
     unsafe fn dealloc(&mut self, _ptr: *mut u8, _layout: Layout) {
         // Sofar nothing - don't worry, RAM is cheap
     }
-}
+}    
 
 
-/// Align downwards. Returns the greatest x with alignment `align`
-/// so that x <= addr. The alignment must be a power of 2.
+// Align downwards. Returns the greatest x with alignment `align`
+// so that x <= addr. The alignment must be a power of 2.
 pub fn align_down(addr: usize, align: usize) -> usize {
     if align.is_power_of_two() {
         addr & !(align - 1)
@@ -83,12 +125,10 @@ pub fn align_down(addr: usize, align: usize) -> usize {
     }
 }
 
-/// Align upwards. Returns the smallest x with alignment `align`
-/// so that x >= addr. The alignment must be a power of 2.
+// Align upwards. Returns the smallest x with alignment `align`
+// so that x >= addr. The alignment must be a power of 2.
 pub fn align_up(addr: usize, align: usize) -> usize {
     align_down(addr + align - 1, align)
 }
 
-#[global_allocator]
-static GLOBAL_ALLOC: Allocator = Allocator;
 

--- a/libs/bump_allocator/src/lib.rs
+++ b/libs/bump_allocator/src/lib.rs
@@ -21,9 +21,6 @@ extern crate alloc;
 extern crate spin;
 
 
-pub const HEAP_START: usize = 0o_000_001_000_000_0000;
-pub const HEAP_SIZE: usize = 100 * 1024; // 100 KiB
-
 static HEAP: Mutex<Heap> = Mutex::new(Heap::new(0, 0));
 
 //Set up the heap

--- a/libs/hole_list_allocator/src/lib.rs
+++ b/libs/hole_list_allocator/src/lib.rs
@@ -22,8 +22,6 @@ use alloc::heap::{Alloc, AllocErr, Layout};
 use spin::Mutex;
 use linked_list_allocator::Heap;
 
-pub const HEAP_START: usize = 0o_000_001_000_000_0000;
-pub const HEAP_SIZE: usize = 100 * 1024; // 100 KiB
 
 static HEAP: Mutex<Option<Heap>> = Mutex::new(None);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,11 @@ mod memory;
 
 mod interrupts;
 
+
+pub const HEAP_START: usize = 0o_000_001_000_000_0000;
+pub const HEAP_SIZE: usize = 100 * 1024; // 100 KiB
+
+
 #[no_mangle]
 pub extern "C" fn rust_main(multiboot_information_address: usize) {
     // ATTENTION: we have a very small stack and no guard page

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -63,7 +63,7 @@ pub fn init(boot_info: &BootInformation) -> MemoryController {
     let mut active_table = paging::remap_the_kernel(&mut frame_allocator, boot_info);
 
     use self::paging::Page;
-    use allocator::{HEAP_START, HEAP_SIZE};
+    use super::{HEAP_START, HEAP_SIZE};
 
     let heap_start_page = Page::containing_address(HEAP_START);
     let heap_end_page = Page::containing_address(HEAP_START + HEAP_SIZE - 1);


### PR DESCRIPTION
This version follows the new interface. I've tried to make the transition to the existing version of the hole_list_allocator easier so I've kept that pattern of having a init() function etc. 

If this version of the bump allocator is ok I could do a rewrite of the instructions in the blog.