### PR TITLE
Fix ld error: Undefined symbol eh_personality.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,8 @@ fn enable_write_protect_bit() {
 
 #[cfg(not(test))]
 #[lang = "eh_personality"]
-extern "C" fn eh_personality() {}
+#[no_mangle]
+pub extern "C" fn eh_personality() {}
 
 #[cfg(not(test))]
 #[lang = "panic_fmt"]


### PR DESCRIPTION
This can be fixed by telling the compiler not to mangle the function. Maybe something was changed so that you have to explicitly state to the compiler not the optimise the function away? I don't know. Point is, this builds for me now, whereas before cloning the repo fresh would throw up link errors.