### PR TITLE
Add missing semicolon in double-fault post

### DIFF
--- a/blog/content/posts/10-double-faults/index.md
+++ b/blog/content/posts/10-double-faults/index.md
@@ -70,7 +70,7 @@ lazy_static! {
         let mut idt = idt::Idt::new();
 
         idt.breakpoint.set_handler_fn(breakpoint_handler);
-        idt.double_fault.set_handler_fn(double_fault_handler)
+        idt.double_fault.set_handler_fn(double_fault_handler);
 
         idt
     };


### PR DESCRIPTION
The example code won't compile without a semicolon after the call to `set_handler_fn`.

Sorry for the lazy branch name, did this from the github UI.