### PR TITLE
[Fix #362] Fix sign extension bug in `next_table_address`

### DIFF
--- a/src/memory/paging/table.rs
+++ b/src/memory/paging/table.rs
@@ -39,7 +39,8 @@ where
         let entry_flags = self[index].flags();
         if entry_flags.contains(PRESENT) && !entry_flags.contains(HUGE_PAGE) {
             let table_address = self as *const _ as usize;
-            Some((table_address << 9) | (index << 12))
+            let sign_extension = 0o177777_000_000_000_000_0000 * ((table_address >> 47) & 0b1);
+            Some(((table_address << 9) | (index << 12)) & ((1 << 48) - 1) | sign_extension)
         } else {
             None
         }

--- a/src/memory/paging/table.rs
+++ b/src/memory/paging/table.rs
@@ -31,6 +31,15 @@ where
     }
 }
 
+/*
+ * Addresses are expected to be canonical (bits 48-63 must be the same as bit 47), otherwise the
+ * CPU will #GP when we ask it to translate it.
+ */
+fn make_address_canonical(address : usize) -> usize {
+    let sign_extension = 0o177777_000_000_000_000_0000 * ((address >> 47) & 0b1);
+    (address & ((1 << 48) - 1)) | sign_extension
+}
+
 impl<L> Table<L>
 where
     L: HierarchicalLevel,
@@ -39,8 +48,7 @@ where
         let entry_flags = self[index].flags();
         if entry_flags.contains(PRESENT) && !entry_flags.contains(HUGE_PAGE) {
             let table_address = self as *const _ as usize;
-            let sign_extension = 0o177777_000_000_000_000_0000 * ((table_address >> 47) & 0b1);
-            Some(((table_address << 9) | (index << 12)) & ((1 << 48) - 1) | sign_extension)
+            Some(make_address_canonical((table_address << 9) | (index << 12)))
         } else {
             None
         }


### PR DESCRIPTION
Fix an issue where the left shift of the old table address would overwrite the sign extension, making the
address non-canonical and leading to #GPs. This calculates the correct sign extension for the new table
address.