### PR TITLE
Use proper size for heap init

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub extern "C" fn rust_main(multiboot_information_address: usize) {
     let mut memory_controller = memory::init(boot_info);
 
     unsafe {
-        HEAP_ALLOCATOR.lock().init(HEAP_START, HEAP_START + HEAP_SIZE);
+        HEAP_ALLOCATOR.lock().init(HEAP_START, HEAP_SIZE);
     }
 
     // initialize our IDT


### PR DESCRIPTION
The `LockedHeap.init()` function takes `heap_bottom` and `heap_size` as arguments.  Instead, we pass `heap_bottom` and `heap_top`.

This led to unexpected page faults and other weird behavior because the hole sizes were incorrect.