### PR TITLE
Fix travis by cleaning libraries built with stale nightly compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: rust
 rust:
     - nightly
 
-cache: cargo
+cache:
+  directories:
+    - $HOME/.cargo
 
 before_script:
   - rustup component add rust-src


### PR DESCRIPTION
Travis is currently failing with the following message:

```
36.08s$ make
   Compiling core v0.0.0 (file:///home/travis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore)
   Compiling std_unicode v0.0.0 (file:///home/travis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd_unicode)
   Compiling alloc v0.0.0 (file:///home/travis/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/liballoc)
    Finished release [optimized] target(s) in 34.81 secs
    Updating registry `https://github.com/rust-lang/crates.io-index`
   Compiling blog_os v0.1.0 (file:///home/travis/build/phil-opp/blog_os)
error[E0460]: found possibly newer version of crate `core` which `rlibc` depends on
  --> src/lib.rs:23:1
   |
23 | extern crate rlibc;
   | ^^^^^^^^^^^^^^^^^^^
   |
   = note: perhaps that crate needs to be recompiled?
   = note: the following crate versions were found:
           crate `core`: /home/travis/.xargo/lib/rustlib/x86_64-blog_os/lib/libcore-58f01dc603992338.rlib
           crate `rlibc`: /home/travis/build/phil-opp/blog_os/target/x86_64-blog_os/debug/deps/librlibc-8eabc116dc6e8246.rlib
```

[I have hit the same issue in my repo](https://travis-ci.org/robert-w-gries/rxinu/jobs/318464189#L586), and I believe the issue is that Travis caches the previously built libraries.  The failure is triggered when Travis pulls in a new nightly compiler and attempts to build our kernel with libraries built by an old nightly compiler.

The solution is to ensure our libraries are built with the latest nightly compiler.  I accomplished this by running `make clean` before building the kernel.