### PR TITLE
Allow users to use latest nightly compiler without manually setting environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ addons:
       - nasm
 
 script:
-  - make RUST_TARGET_PATH=`pwd`
+  - make

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(kernel): cargo $(rust_os) $(assembly_object_files) $(linker_script)
 	@ld -n --gc-sections -T $(linker_script) -o $(kernel) $(assembly_object_files) $(rust_os)
 
 cargo:
-	@xargo build --target $(target)
+	@RUST_TARGET_PATH="$(shell pwd)" xargo build --target $(target)
 
 # compile assembly files
 build/arch/$(arch)/%.o: src/arch/$(arch)/%.asm


### PR DESCRIPTION
This PR resolves #379 by manually setting `RUST_TARGET_PATH` to `pwd` in the makefile.

[Some background can be found in this comment:](https://github.com/japaric/xargo/issues/186#issuecomment-354503358)

>Due to rust-lang/cargo#4788 now all users of custom targets will have to set RUST_TARGET_PATH to the directory that contains the specification file if they have any dependency declared in Cargo.toml.

There hasn't been any activity regarding the breakage caused by rust-lang/cargo#4788, so let's change the Makefile so that users don't have to manually set the nightly version anymore.