### PR TITLE
Fix eh_personality reference error

### DIFF
--- a/blog/content/posts/03-set-up-rust/index.md
+++ b/blog/content/posts/03-set-up-rust/index.md
@@ -54,7 +54,7 @@ Now we place our root source file in `src/lib.rs`:
 #[no_mangle]
 pub extern fn rust_main() {}
 
-#[lang = "eh_personality"] extern fn eh_personality() {}
+#[lang = "eh_personality"] #[no_mangle] extern fn eh_personality() {}
 #[lang = "panic_fmt"] #[no_mangle] pub extern fn panic_fmt() -> ! {loop{}}
 ```
 Let's break it down:

--- a/blog/content/posts/03-set-up-rust/index.md
+++ b/blog/content/posts/03-set-up-rust/index.md
@@ -54,7 +54,7 @@ Now we place our root source file in `src/lib.rs`:
 #[no_mangle]
 pub extern fn rust_main() {}
 
-#[lang = "eh_personality"] #[no_mangle] extern fn eh_personality() {}
+#[lang = "eh_personality"] #[no_mangle] pub extern fn eh_personality() {}
 #[lang = "panic_fmt"] #[no_mangle] pub extern fn panic_fmt() -> ! {loop{}}
 ```
 Let's break it down:


### PR DESCRIPTION
Fix issue with undefined reference to `rust_eh_personality' when compiling in blog post