### PR TITLE
Update `"panic"` to `"panic-strategy"`

### DIFF
--- a/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
@@ -143,7 +143,7 @@ Instead of using the platform's default linker (which might not support Linux ta
 [LLD]: https://lld.llvm.org/
 
 ```json
-"panic": "abort",
+"panic-strategy": "abort",
 ```
 
 This setting specifies that the target doesn't support [stack unwinding] on panic, so instead the program should abort directly. This has the same effect as the `panic = "abort"` option in our Cargo.toml, so we can remove it from there.
@@ -189,7 +189,7 @@ Our target specification file now looks like this:
   "executables": true,
   "features": "-mmx,-sse,+soft-float",
   "disable-redzone": true,
-  "panic": "abort"
+  "panic-strategy": "abort"
 }
 ```
 

--- a/x86_64-blog_os.json
+++ b/x86_64-blog_os.json
@@ -11,5 +11,5 @@
   "executables": true,
   "features": "-mmx,-sse,+soft-float",
   "disable-redzone": true,
-  "panic": "abort"
+  "panic-strategy": "abort"
 }


### PR DESCRIPTION
Corrected typo in second edition blog post.

Closes #391.