### PR TITLE
Add information on rust-toolchain file to post 3

### DIFF
--- a/blog/content/posts/03-set-up-rust/index.md
+++ b/blog/content/posts/03-set-up-rust/index.md
@@ -21,7 +21,11 @@ This blog post tries to set up Rust step-by-step and point out the different pro
 [Github repository]: https://github.com/phil-opp/blog_os/tree/post_3
 
 ## Installing Rust
-We need a nightly compiler, as we will use many unstable features. To manage Rust installations I highly recommend [rustup]. It allows you to install nightly, beta, and stable compilers side-by-side and makes it easy to update them. To use a nightly compiler for the current directory, you can run `rustup override add nightly`.
+We need a nightly compiler, as we will use many unstable features. To manage Rust installations I highly recommend [rustup]. It allows you to install nightly, beta, and stable compilers side-by-side and makes it easy to update them. To use a nightly compiler for the current directory, you can run `rustup override add nightly`. Alternatively, you can add a file called `rust-toolchain` to the project's root directory:
+
+```
+nightly
+```
 
 [rustup]: https://www.rustup.rs/
 


### PR DESCRIPTION
Not entirely necessary, but I moved the project directory around a couple of times, which broke the override I set with `rustup override`. The `rust-toolchain` file can be used to keep you from having to set the override again when the directory is moved. Using a `rust-toolchain` file works since rustup 1.5.0.

References:
* [rustup changelog](https://github.com/rust-lang-nursery/rustup.rs/blob/master/CHANGELOG.md#150)
* [rustup PR adding rust-toolchain file functionality](https://github.com/rust-lang-nursery/rustup.rs/pull/1172)