### PR TITLE
Remove extra "the"

### DIFF
--- a/blog/content/second-edition/posts/01-freestanding-rust-binary/index.md
+++ b/blog/content/second-edition/posts/01-freestanding-rust-binary/index.md
@@ -278,7 +278,7 @@ pub extern fn WinMain() -> ! {
 We just call `WinMain` from `WinMainCRTStartup` to avoid any ambiguity which function is called.
 
 #### macOS
-macOS [does not support statically linked binaries], so we have to link the `libSystem` library. The entry point is the called `main`:
+macOS [does not support statically linked binaries], so we have to link the `libSystem` library. The entry point is called `main`:
 
 [does not support statically linked binaries]: https://developer.apple.com/library/content/qa/qa1118/_index.html
 


### PR DESCRIPTION
There is an extra word in "the entry point is _the_ called `main`".

It's possible that "the entry point is _then_ called `main`" was intended,
but it works without the word just as well, so just remove it.