### PR TITLE
Rust automatically injects a dependency on `compiler_builtins` now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ name = "blog_os"
 version = "0.2.0"
 
 [dependencies]
-rlibc = "1.0"
 spin = "0.4.6"
 volatile = "0.2.3"
 

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,0 +1,6 @@
+[dependencies.core]
+stage = 0
+
+[dependencies.compiler_builtins]
+features = ["mem"]
+stage = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 #![no_std] // don't link the Rust standard library
 #![no_main] // disable all Rust-level entry points
 
-extern crate rlibc;
 extern crate spin;
 extern crate volatile;
 #[macro_use]


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/49503, Rust automatically injects a dependency on `compiler_builtins` whenever a dependency on `core` is injected (i.e. all `no_std` applications that aren't `no_core`). This means that compilation fails if xargo builds only `core` (which is the default).

To also build `compiler_builtins`, a `Xargo.toml` with the following content is required:

```toml
[dependencies.core]
stage = 0

[dependencies.compiler_builtins]
features = ["mem"]
stage = 1
```

The `features = ["mem"]` line is not required, but removes the need for `rlibc`.