### PR TITLE
No more RUST_TARGET_PATH

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,7 +38,6 @@ environment:
 cache:
   - '%USERPROFILE%\.cargo\bin'
   - '%USERPROFILE%\.cargo\.crates.toml'
-  - '%USERPROFILE%\.xargo'
   - target
 
 ## Install Script ##
@@ -70,7 +69,7 @@ before_test:
   - rustup component add rust-src
   - set RUST_BACKTRACE=1
   - if not exist %USERPROFILE%\.cargo\bin\cargo-install-update.exe cargo install cargo-update
-  - if not exist %USERPROFILE%\.cargo\bin\xargo.exe cargo install xargo
+  - if not exist %USERPROFILE%\.cargo\bin\cargo-xbuild.exe cargo install cargo-xbuild
   - if not exist %USERPROFILE%\.cargo\bin\bootimage.exe cargo install bootimage
   - cargo install-update -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,12 @@ os:
   - linux
   - osx
 
-cache:
-  directories:
-    - $HOME/.cargo
-    - $HOME/.xargo
-    - $TRAVIS_BUILD_DIR/target
+cache: cargo
 
 before_script:
   - rustup component add rust-src
   - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-  - (test -x $HOME/.cargo/bin/xargo || cargo install xargo)
+  - (test -x $HOME/.cargo/bin/cargo-xbuild || cargo install cargo-xbuild)
   - (test -x $HOME/.cargo/bin/bootimage || cargo install bootimage)
   - cargo install-update -a
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ panic = "abort" # disable stack unwinding on panic
 panic = "abort" # disable stack unwinding on panic
 
 [package.metadata.bootimage]
-default-target = "x86_64-blog_os"
+default-target = "x86_64-blog_os.json"

--- a/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
@@ -317,9 +317,13 @@ Now that we have an executable that does something perceptible, it is time to tu
 
 [section about booting]: #the-boot-process
 
-To make things easy, we created a tool named `bootimage` that automatically downloads a bootloader and combines it with the kernel executable to create a bootable disk image. To install it, execute `cargo install bootimage` in your terminal.
+To make things easy, we created a tool named `bootimage` that automatically downloads a bootloader and combines it with the kernel executable to create a bootable disk image. To install it, execute `cargo install bootimage` in your terminal. After installing, creating a bootimage is as easy as executing:
 
-After installing, creating a bootimage is as easy as executing `bootimage build --target x86_64-blog_os.json`. The tool also recompiles your kernel using `cargo xbuild`, so it will automatically pick up any changes you make.
+```
+> bootimage build --target x86_64-blog_os.json
+```
+
+The tool also recompiles your kernel using `cargo xbuild`, so it will automatically pick up any changes you make.
 
 After executing the command, you should see a file named `bootimage.bin` in your crate root directory. This file is a bootable disk image. You can boot it in a virtual machine or copy it to an USB drive to boot it on real hardware. (Note that this is not a CD image, which have a different format, so burning it to a CD doesn't work).
 


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/49019 Rust supports passing paths as `--target` (with `.json` extension). With https://github.com/rust-lang/cargo/pull/5228, Cargo automatically converts these paths to absolute paths, so that the `RUST_TARGET_PATH` environment variable is no longer neccessary.

The only missing piece was [xargo](https://github.com/japaric/xargo), but unfortunatly the PR at https://github.com/japaric/xargo/pull/205 got no attention. Since there are other unaddressed issues (e.g. https://github.com/japaric/xargo/issues/214) and xargo is in maintainance mode, we decided to create [cargo-xbuild](https://github.com/rust-osdev/cargo-xbuild) as a simplified fork of xargo to fix these issues.

This PR updates the second edition to use `cargo xbuild` instead of `xargo` and removes `RUST_TARGET_PATH` by passing paths as `--target`.