### PR TITLE
Fixed an erroneous call to unwrap() in second edition vga buffer chapter

### DIFF
--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -347,7 +347,7 @@ pub fn print_something() {
     };
 
     writer.write_byte(b'H');
-    writer.write_str("ello! ").unwrap();
+    writer.write_str("ello! ");
     write!(writer, "The numbers are {} and {}", 42, 1.0/3.0).unwrap();
 }
 ```


### PR DESCRIPTION
In an example code block in the second edition chapter on VGA buffers, there was a call to unwrap() chained with write_str(). But write_str() doesn't return anything, and thus there is nothing to unwrap().