### PR TITLE
Fix links that pointed to a redirection page

### DIFF
--- a/blog/content/first-edition/posts/04-printing-to-screen/index.md
+++ b/blog/content/first-edition/posts/04-printing-to-screen/index.md
@@ -312,7 +312,7 @@ struct Buffer {
 ```
 Instead of a `ScreenChar`, we're now using a `Volatile<ScreenChar>`. (The `Volatile` type is [generic] and can wrap (almost) any type). This ensures that we can't accidentally write to it through a “normal” write. Instead, we have to use the `write` method now.
 
-[generic]: https://doc.rust-lang.org/book/generics.html
+[generic]: https://doc.rust-lang.org/book/second-edition/ch10-00-generics.html
 
 This means that we have to update our `Writer::write_byte` method:
 
@@ -505,7 +505,7 @@ Note that we need to import the `Write` trait if we want to use its functions.
 ## A println macro
 Rust's [macro syntax] is a bit strange, so we won't try to write a macro from scratch. Instead we look at the source of the [`println!` macro] in the standard library:
 
-[macro syntax]: https://doc.rust-lang.org/nightly/book/macros.html
+[macro syntax]: https://doc.rust-lang.org/nightly/reference/macros-by-example.html
 [`println!` macro]: https://doc.rust-lang.org/nightly/std/macro.println!.html
 
 ```rust

--- a/blog/content/first-edition/posts/04-printing-to-screen/index.md
+++ b/blog/content/first-edition/posts/04-printing-to-screen/index.md
@@ -442,7 +442,7 @@ But we can't use it to print anything! You can try it yourself in the `print_som
 
 To resolve it, we could use a [mutable static]. But then every read and write to it would be unsafe since it could easily introduce data races and other bad things. Using `static mut` is highly discouraged, there are even proposals to [remove it][remove static mut].
 
-[mutable static]: https://doc.rust-lang.org/book/const-and-static.html#mutability
+[mutable static]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html#accessing-or-modifying-a-mutable-static-variable
 [remove static mut]: https://internals.rust-lang.org/t/pre-rfc-remove-static-mut/1437
 
 But what are the alternatives? We could try to use a cell type like [RefCell] or even [UnsafeCell] to provide [interior mutability]. But these types aren't [Sync] \(with good reason), so we can't use them in statics.

--- a/blog/content/first-edition/posts/04-printing-to-screen/index.md
+++ b/blog/content/first-edition/posts/04-printing-to-screen/index.md
@@ -505,7 +505,7 @@ Note that we need to import the `Write` trait if we want to use its functions.
 ## A println macro
 Rust's [macro syntax] is a bit strange, so we won't try to write a macro from scratch. Instead we look at the source of the [`println!` macro] in the standard library:
 
-[macro syntax]: https://doc.rust-lang.org/nightly/reference/macros-by-example.html
+[macro syntax]: https://doc.rust-lang.org/nightly/book/second-edition/appendix-04-macros.html
 [`println!` macro]: https://doc.rust-lang.org/nightly/std/macro.println!.html
 
 ```rust

--- a/blog/content/first-edition/posts/09-handling-exceptions/index.md
+++ b/blog/content/first-edition/posts/09-handling-exceptions/index.md
@@ -316,7 +316,7 @@ pub fn init() {
 There are two problems with this. First, statics are immutable, so we can't modify the breakpoint entry from our `init` function. Second, the `Idt::new` function is not a [`const` function], so it can't be used to initialize a `static`. We could solve this problem by using a [`static mut`] of type `Option<Idt>`:
 
 [`const` function]: https://github.com/rust-lang/rfcs/blob/master/text/0911-const-fn.md
-[`static mut`]: https://doc.rust-lang.org/book/const-and-static.html#mutability
+[`static mut`]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html#accessing-or-modifying-a-mutable-static-variable
 
 ```rust
 static mut IDT: Option<Idt> = None;
@@ -333,7 +333,7 @@ pub fn init() {
 
 This variant compiles without errors but it's far from idiomatic. `static mut`s are very prone to data races, so we need an [`unsafe` block] on each access. Also, we need to explicitly `unwrap` the `IDT` on each use, since might be `None`.
 
-[`unsafe` block]: https://doc.rust-lang.org/book/unsafe.html#unsafe-superpowers
+[`unsafe` block]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html#unsafe-superpowers
 
 #### Lazy Statics to the Rescue
 The one-time initialization of statics with non-const functions is a common problem in Rust. Fortunately, there already exists a good solution in a crate named [lazy_static]. This crate provides a `lazy_static!` macro that defines a lazily initialized `static`. Instead of computing its value at compile time, the `static` laziliy initializes itself when it's accessed the first time. Thus, the initialization happens at runtime so that arbitrarily complex initialization code is possible.

--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -543,7 +543,7 @@ Note that we only have a single unsafe block in our code, which is needed to cre
 ### A println Macro
 Now that we have a global writer, we can add a `println` macro that can be used from anywhere in the codebase. Rust's [macro syntax] is a bit strange, so we won't try to write a macro from scratch. Instead we look at the source of the [`println!` macro] in the standard library:
 
-[macro syntax]: https://doc.rust-lang.org/nightly/reference/macros-by-example.html
+[macro syntax]: https://doc.rust-lang.org/nightly/book/second-edition/appendix-04-macros.html
 [`println!` macro]: https://doc.rust-lang.org/nightly/std/macro.println!.html
 
 ```rust

--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -292,7 +292,7 @@ struct Buffer {
 ```
 Instead of a `ScreenChar`, we're now using a `Volatile<ScreenChar>`. (The `Volatile` type is [generic] and can wrap (almost) any type). This ensures that we can't accidentally write to it through a “normal” write. Instead, we have to use the `write` method now.
 
-[generic]: https://doc.rust-lang.org/book/generics.html
+[generic]: https://doc.rust-lang.org/book/second-edition/ch10-00-generics.html
 
 This means that we have to update our `Writer::write_byte` method:
 
@@ -543,7 +543,7 @@ Note that we only have a single unsafe block in our code, which is needed to cre
 ### A println Macro
 Now that we have a global writer, we can add a `println` macro that can be used from anywhere in the codebase. Rust's [macro syntax] is a bit strange, so we won't try to write a macro from scratch. Instead we look at the source of the [`println!` macro] in the standard library:
 
-[macro syntax]: https://doc.rust-lang.org/nightly/book/macros.html
+[macro syntax]: https://doc.rust-lang.org/nightly/reference/macros-by-example.html
 [`println!` macro]: https://doc.rust-lang.org/nightly/std/macro.println!.html
 
 ```rust

--- a/blog/content/second-edition/posts/06-cpu-exceptions/index.md
+++ b/blog/content/second-edition/posts/06-cpu-exceptions/index.md
@@ -317,7 +317,7 @@ pub fn init_idt() {
 
 However, there is a problem: Statics are immutable, so we can't modify the breakpoint entry from our `init` function. We could solve this problem by using a [`static mut`]:
 
-[`static mut`]: https://doc.rust-lang.org/book/const-and-static.html#mutability
+[`static mut`]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html#accessing-or-modifying-a-mutable-static-variable
 
 ```rust
 static mut IDT: Option<Idt> = Idt::new();
@@ -332,7 +332,7 @@ pub fn init_idt() {
 
 This variant compiles without errors but it's far from idiomatic. `static mut`s are very prone to data races, so we need an [`unsafe` block] on each access.
 
-[`unsafe` block]: https://doc.rust-lang.org/book/unsafe.html#unsafe-superpowers
+[`unsafe` block]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html#unsafe-superpowers
 
 #### Lazy Statics to the Rescue
 Fortunately the `lazy_static` macro exists. Instead of evaluating a `static` at compile time, the macro performs the initialization when the `static` is referenced the first time. Thus, we can do almost everything in the initialization block and are even able to read runtime values.


### PR DESCRIPTION
For #445 

These were the only links I found that pointed to the "There is a new edition of the book and this is an old link." page.

With this merged, I'd consider #445 fixed