### PR TITLE
Fix: should be `main.rs` instead of `lib.rs`

### DIFF
--- a/blog/content/second-edition/posts/06-cpu-exceptions/index.md
+++ b/blog/content/second-edition/posts/06-cpu-exceptions/index.md
@@ -263,7 +263,7 @@ error: x86-interrupt ABI is experimental and subject to change (see issue #40180
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 ```
 
-This error occurs because the `x86-interrupt` calling convention is still unstable. To use it anyway, we have to explicitly enable it by adding `#![feature(abi_x86_interrupt)]` on the top of our `lib.rs`.
+This error occurs because the `x86-interrupt` calling convention is still unstable. To use it anyway, we have to explicitly enable it by adding `#![feature(abi_x86_interrupt)]` on the top of our `main.rs`.
 
 ### Loading the IDT
 In order that the CPU uses our new interrupt descriptor table, we need to load it using the [`lidt`] instruction. The `Idt` struct of the `x86_64` provides a [`load`][Idt::load] method function for that. Let's try to use it:

--- a/blog/content/second-edition/posts/06-cpu-exceptions/index.md
+++ b/blog/content/second-edition/posts/06-cpu-exceptions/index.md
@@ -249,16 +249,13 @@ Our handler just outputs a message and pretty-prints the exception stack frame.
 When we try to compile it, the following error occurs:
 
 ```
-error: x86-interrupt ABI is experimental and subject to change (see issue #40180)
-  --> src/interrupts.rs:8:1
+error[E0658]: x86-interrupt ABI is experimental and subject to change (see issue #40180)
+  --> src/main.rs:53:1
    |
-8  |   extern "x86-interrupt" fn breakpoint_handler(
-   |  _^ starting here...
-9  | |     stack_frame: &mut ExceptionStackFrame)
-10 | | {
-11 | |     println!("EXCEPTION: BREAKPOINT\n{:#?}", stack_frame);
-12 | | }
-   | |_^ ...ending here
+53 | / extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut ExceptionStackFrame) {
+54 | |     println!("EXCEPTION: BREAKPOINT\n{:#?}", stack_frame);
+55 | | }
+   | |_^
    |
    = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
 ```


### PR DESCRIPTION
The feature flag for `abi_x86_interrupt` needs to be in `main.rs`.
Putting the feature flag in my lib.rs did not resolve the error. I assume this was an oversight when updating this chapter from the first edition, because the error message in the blog also refers to a separate module `interrupts.rs` that was never mentioned in this edition.