### PR TITLE
Add missing semicolon in integration tests post

### DIFF
--- a/blog/content/second-edition/posts/05-integration-tests/index.md
+++ b/blog/content/second-edition/posts/05-integration-tests/index.md
@@ -77,7 +77,7 @@ The `uart_16550` crate contains a `SerialPort` struct that represents the UART r
 ```rust
 // in src/main.rs
 
-mod serial
+mod serial;
 ```
 
 ```rust


### PR DESCRIPTION
Just a typo patch -- there was a missing semicolon after the module declaration in the example code.

Edit: It appears the travis build is failing for unrelated reasons.