### PR TITLE
Update to bootimage 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,11 +21,20 @@ name = "blog_os"
 version = "0.2.0"
 dependencies = [
  "array-init 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader_precompiled 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uart_16550 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "volatile 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bootloader_precompiled"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -91,6 +100,7 @@ dependencies = [
 "checksum array-init 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c3cc8456d0ae81a8c76f59e384683a601548c38949a4bfcb65dd31ded5c75ff3"
 "checksum bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum bootloader_precompiled 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "245362094f3e7e5c801e71646a672c1fa895c033ca47473278e3d99af6300be6"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum os_bootinfo 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "66481dbeb5e773e7bd85b63cd6042c30786f834338288c5ec4f3742673db360a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ name = "blog_os"
 version = "0.2.0"
 
 [dependencies]
+bootloader_precompiled = "0.2.0"
 spin = "0.4.6"
 volatile = "0.2.3"
 uart_16550 = "0.1.0"

--- a/blog/content/second-edition/posts/05-integration-tests/index.md
+++ b/blog/content/second-edition/posts/05-integration-tests/index.md
@@ -374,6 +374,7 @@ Cargo supports hybrid projects that are both a library and a binary. We only nee
 
 #![no_std] // don't link the Rust standard library
 
+extern crate bootloader_precompiled;
 extern crate spin;
 extern crate volatile;
 #[macro_use]

--- a/blog/content/second-edition/posts/05-integration-tests/index.md
+++ b/blog/content/second-edition/posts/05-integration-tests/index.md
@@ -585,17 +585,14 @@ The `test-basic-boot` and `test-panic` tests we created above begin with `test-`
 > bootimage test
 test-panic
     Finished dev [unoptimized + debuginfo] target(s) in 0.01s
-    Updating registry `https://github.com/rust-lang/crates.io-index`
 Ok
 
 test-basic-boot
     Finished dev [unoptimized + debuginfo] target(s) in 0.01s
-    Updating registry `https://github.com/rust-lang/crates.io-index`
 Ok
 
 test-something
     Finished dev [unoptimized + debuginfo] target(s) in 0.01s
-    Updating registry `https://github.com/rust-lang/crates.io-index`
 Timed Out
 
 The following tests failed:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std] // don't link the Rust standard library
 
+extern crate bootloader_precompiled;
 extern crate spin;
 extern crate volatile;
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ extern crate blog_os;
 extern crate x86_64;
 #[macro_use]
 extern crate lazy_static;
+extern crate bootloader_precompiled;
 
 use core::panic::PanicInfo;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ extern crate blog_os;
 extern crate x86_64;
 #[macro_use]
 extern crate lazy_static;
-extern crate bootloader_precompiled;
 
 use core::panic::PanicInfo;
 


### PR DESCRIPTION
See https://github.com/rust-osdev/bootimage/pull/16 and https://github.com/rust-osdev/bootloader/pull/20.