### PR TITLE
[second edition: 03 vga text buffer] Fix example code

### DIFF
--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -347,7 +347,7 @@ pub fn print_something() {
     };
 
     writer.write_byte(b'H');
-    writer.write_str("ello! ").unwrap();
+    writer.write_string("ello! ");
     write!(writer, "The numbers are {} and {}", 42, 1.0/3.0).unwrap();
 }
 ```


### PR DESCRIPTION
Writer.write_str does not return Result so it should be error if we call unwrap()