### PR TITLE
Refactor exception code into new `interrupts` module

### DIFF
--- a/blog/content/second-edition/posts/06-cpu-exceptions/index.md
+++ b/blog/content/second-edition/posts/06-cpu-exceptions/index.md
@@ -204,7 +204,7 @@ If you are interested in more details: We also have a series of posts that expla
 [too-much-magic]: #too-much-magic
 
 ## Implementation
-Now that we've understood the theory, it's time to handle CPU exceptions in our kernel. We start by creating an `init_idt` function that creates a new `InterruptDescriptorTable`:
+Now that we've understood the theory, it's time to handle CPU exceptions in our kernel. We'll start by creating a new interrupts module in `src/interrupts.rs`, that first creates an `init_idt` function that creates a new `InterruptDescriptorTable`:
 
 ``` rust
 // in src/lib.rs

--- a/blog/content/second-edition/posts/06-cpu-exceptions/index.md
+++ b/blog/content/second-edition/posts/06-cpu-exceptions/index.md
@@ -300,7 +300,7 @@ pub mod interrupts;
 pub mod serial;
 ```
 
-Now we can use our `print!` and `println!` macros in `interrupts.rs`. If you'd like to know more about the ins and outs of macros and how they differ from functions [you can find more information here](in-depth-rust-macros).
+Now we can use our `print!` and `println!` macros in `interrupts.rs`. If you'd like to know more about the ins and outs of macros and how they differ from functions [you can find more information here][in-depth-rust-macros].
 
 [in-depth-rust-macros]: https://doc.rust-lang.org/book/second-edition/appendix-04-macros.html
 
@@ -442,7 +442,7 @@ static BREAKPOINT_HANDLER_CALLED: AtomicUsize = AtomicUsize::new(0);
 #[cfg(not(test))]
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    blog_os::interrupts::init_idt();
+    init_idt();
 
     // invoke a breakpoint exception
     x86_64::instructions::int3();

--- a/blog/content/second-edition/posts/06-cpu-exceptions/index.md
+++ b/blog/content/second-edition/posts/06-cpu-exceptions/index.md
@@ -276,7 +276,19 @@ error: cannot find macro `println!` in this scope
    = help: have you added the `#[macro_use]` on the module/import?
 ```
 
-And this error occurs because the `print!` and `println!` macros we created in the `vga_buffer` _must be defined_ before we use them. This is one case where import order matters in Rust. We can easily fix this by ensuring the order of our imports places the macros first:
+This happened because we forgot to add `#[macro_use]` before our import of the `vga_buffer` module.
+
+```rust
+// in src/lib.rs
+
+pub mod gdt;
+pub mod interrupts;
+pub mod serial;
+#[macro_use] // new
+pub mod vga_buffer;
+```
+
+However, after adding `#[macro_use]` before the module import, we still get the same error. Sometimes this can be confusing, but it's actually a quirk of how Rust's macro system works. Macros _must be defined_ before you can use them. This is one case where import order matters in Rust. We can easily fix this by ensuring the order of our imports places the macros first:
 
 ```rust
 // in src/lib.rs

--- a/src/bin/test-exception-breakpoint.rs
+++ b/src/bin/test-exception-breakpoint.rs
@@ -18,7 +18,7 @@ static BREAKPOINT_HANDLER_CALLED: AtomicUsize = AtomicUsize::new(0);
 #[cfg(not(test))]
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-    init_idt();
+    init_test_idt();
 
     // invoke a breakpoint exception
     x86_64::instructions::int3();
@@ -59,15 +59,15 @@ fn panic(info: &PanicInfo) -> ! {
 use x86_64::structures::idt::{ExceptionStackFrame, InterruptDescriptorTable};
 
 lazy_static! {
-    static ref IDT: InterruptDescriptorTable = {
+    static ref TEST_IDT: InterruptDescriptorTable = {
         let mut idt = InterruptDescriptorTable::new();
         idt.breakpoint.set_handler_fn(breakpoint_handler);
         idt
     };
 }
 
-pub fn init_idt() {
-    IDT.load();
+pub fn init_test_idt() {
+    TEST_IDT.load();
 }
 
 extern "x86-interrupt" fn breakpoint_handler(_stack_frame: &mut ExceptionStackFrame) {

--- a/src/bin/test-exception-double-fault-stack-overflow.rs
+++ b/src/bin/test-exception-double-fault-stack-overflow.rs
@@ -17,7 +17,7 @@ use core::panic::PanicInfo;
 #[allow(unconditional_recursion)]
 pub extern "C" fn _start() -> ! {
     blog_os::gdt::init();
-    init_idt();
+    init_test_idt();
 
     fn stack_overflow() {
         stack_overflow(); // for each recursion, the return address is pushed
@@ -53,7 +53,7 @@ fn panic(info: &PanicInfo) -> ! {
 use x86_64::structures::idt::{ExceptionStackFrame, InterruptDescriptorTable};
 
 lazy_static! {
-    static ref IDT: InterruptDescriptorTable = {
+    static ref TEST_IDT: InterruptDescriptorTable = {
         let mut idt = InterruptDescriptorTable::new();
         unsafe {
             idt.double_fault
@@ -65,8 +65,8 @@ lazy_static! {
     };
 }
 
-pub fn init_idt() {
-    IDT.load();
+pub fn init_test_idt() {
+    TEST_IDT.load();
 }
 
 extern "x86-interrupt" fn double_fault_handler(

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,0 +1,32 @@
+use x86_64::structures::idt::{ExceptionStackFrame, InterruptDescriptorTable};
+use gdt;
+
+lazy_static! {
+    static ref IDT: InterruptDescriptorTable = {
+        let mut idt = InterruptDescriptorTable::new();
+        idt.breakpoint.set_handler_fn(breakpoint_handler);
+        unsafe {
+            idt.double_fault
+                .set_handler_fn(double_fault_handler)
+                .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
+        }
+
+        idt
+    };
+}
+
+pub fn init_idt() {
+    IDT.load();
+}
+
+extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut ExceptionStackFrame) {
+    println!("EXCEPTION: BREAKPOINT\n{:#?}", stack_frame);
+}
+
+extern "x86-interrupt" fn double_fault_handler(
+    stack_frame: &mut ExceptionStackFrame,
+    _error_code: u64,
+) {
+    println!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
+    loop {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std] // don't link the Rust standard library
+#![feature(abi_x86_interrupt)]
 
 extern crate bootloader_precompiled;
 extern crate spin;
@@ -13,9 +14,11 @@ extern crate array_init;
 #[cfg(test)]
 extern crate std;
 
-pub mod gdt;
-pub mod serial;
+#[macro_use]
 pub mod vga_buffer;
+pub mod gdt;
+pub mod interrupts;
+pub mod serial;
 
 pub unsafe fn exit_qemu() {
     use x86_64::instructions::port::Port;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,6 @@
 #[macro_use]
 extern crate blog_os;
 extern crate x86_64;
-#[macro_use]
-extern crate lazy_static;
 
 use core::panic::PanicInfo;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(abi_x86_interrupt)]
 #![no_std] // don't link the Rust standard library
 #![cfg_attr(not(test), no_main)] // disable all Rust-level entry points
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
@@ -19,7 +18,7 @@ pub extern "C" fn _start() -> ! {
     println!("Hello World{}", "!");
 
     blog_os::gdt::init();
-    init_idt();
+    blog_os::interrupts::init_idt();
 
     fn stack_overflow() {
         stack_overflow(); // for each recursion, the return address is pushed
@@ -37,37 +36,5 @@ pub extern "C" fn _start() -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     println!("{}", info);
-    loop {}
-}
-
-use x86_64::structures::idt::{ExceptionStackFrame, InterruptDescriptorTable};
-
-lazy_static! {
-    static ref IDT: InterruptDescriptorTable = {
-        let mut idt = InterruptDescriptorTable::new();
-        idt.breakpoint.set_handler_fn(breakpoint_handler);
-        unsafe {
-            idt.double_fault
-                .set_handler_fn(double_fault_handler)
-                .set_stack_index(blog_os::gdt::DOUBLE_FAULT_IST_INDEX);
-        }
-
-        idt
-    };
-}
-
-pub fn init_idt() {
-    IDT.load();
-}
-
-extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut ExceptionStackFrame) {
-    println!("EXCEPTION: BREAKPOINT\n{:#?}", stack_frame);
-}
-
-extern "x86-interrupt" fn double_fault_handler(
-    stack_frame: &mut ExceptionStackFrame,
-    _error_code: u64,
-) {
-    println!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
     loop {}
 }


### PR DESCRIPTION
As discussed in #473 and https://github.com/acheronfail/blog_os/pull/1/files.

This PR re-writes the 6th and 7th posts so that all exception related code lives in `src/interrupts.rs`.
