### PR TITLE
Minor code adjustments.

### DIFF
--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -176,7 +176,7 @@ impl Writer {
                 let color_code = self.color_code;
                 self.buffer.chars[row][col] = ScreenChar {
                     ascii_character: byte,
-                    color_code: color_code,
+                    color_code,
                 };
                 self.column_position += 1;
             }

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -93,7 +93,7 @@ impl Writer {
                 let color_code = self.color_code;
                 self.buffer.chars[row][col].write(ScreenChar {
                     ascii_character: byte,
-                    color_code: color_code,
+                    color_code,
                 });
                 self.column_position += 1;
             }


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/phil-opp/blog_os/issues/405#issuecomment-431896303). It turns out that I had made a mistake, and the original code uses `...` instead of `..`. It's unclear which syntax out of `...` and `..=` will become standard in future, so we can leave it for now.

Thanks again.