### PR TITLE
Bump spin version as 0.4.6 can't build on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.2.0"
 
 [dependencies]
 bootloader_precompiled = "0.2.0"
-spin = "0.4.6"
+spin = "0.4.9"
 volatile = "0.2.3"
 uart_16550 = "0.1.0"
 x86_64 = "0.2.8"

--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -500,7 +500,7 @@ To use a spinning mutex, we can add the [spin crate] as a dependency:
 ```toml
 # in Cargo.toml
 [dependencies]
-spin = "0.4.6"
+spin = "0.4.9"
 ```
 
 ```rust


### PR DESCRIPTION
When trying to build `spin` 0.4.6 on current nightly, I get the following error:
```
error[E0635]: unknown feature `const_atomic_usize_new`
 --> /home/donald/.cargo/registry/src/github.com-1ecc6299db9ec823/spin-0.4.8/src/lib.rs:8:76
  |
8 | #![cfg_attr(feature = "const_fn", feature(const_fn, const_unsafe_cell_new, const_atomic_usize_new))]
  |                                                                            ^^^^^^^^^^^^^^^^^^^^^^

error[E0635]: unknown feature `const_unsafe_cell_new`
 --> /home/donald/.cargo/registry/src/github.com-1ecc6299db9ec823/spin-0.4.8/src/lib.rs:8:53
  |
8 | #![cfg_attr(feature = "const_fn", feature(const_fn, const_unsafe_cell_new, const_atomic_usize_new))]
  |      
```

This change resolves this, though I haven't tested it for other problems.