### PR TITLE
Modify newline to clone instead of iterate.

### DIFF
--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -363,10 +363,7 @@ Right now, we just ignore newlines and characters that don't fit into the line a
 impl Writer {
     fn new_line(&mut self) {
         for row in 1..BUFFER_HEIGHT {
-            for col in 0..BUFFER_WIDTH {
-                let character = self.buffer.chars[row][col].read();
-                self.buffer.chars[row - 1][col].write(character);
-            }
+            self.buffer.chars[row - 1] = self.buffer.chars[row].clone();
         }
         self.clear_row(BUFFER_HEIGHT - 1);
         self.column_position = 0;

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -119,10 +119,7 @@ impl Writer {
     /// Shifts all lines one line up and clears the last row.
     fn new_line(&mut self) {
         for row in 1..BUFFER_HEIGHT {
-            for col in 0..BUFFER_WIDTH {
-                let character = self.buffer.chars[row][col].read();
-                self.buffer.chars[row - 1][col].write(character);
-            }
+            self.buffer.chars[row - 1] = self.buffer.chars[row].clone();
         }
         self.clear_row(BUFFER_HEIGHT - 1);
         self.column_position = 0;


### PR DESCRIPTION
I've been trying to see what I can do to improve the performance of the VGA text buffer code. This change removes an iterator and clones the next line instead.
As discussed, we'll be able to do a bit more if a VolatileArray is implemented. I also tried to "pre-build" an array for the `clear_row` function to improve performance, but didn't manage to do it without using Vecs.