### PR TITLE
Fix minor url typo for System V ABI on cpu-exceptions page

### DIFF
--- a/blog/content/second-edition/posts/06-cpu-exceptions/index.md
+++ b/blog/content/second-edition/posts/06-cpu-exceptions/index.md
@@ -134,7 +134,7 @@ However, there is a major difference between exceptions and function calls: A fu
 [Calling conventions] specify the details of a function call. For example, they specify where function parameters are placed (e.g. in registers or on the stack) and how results are returned. On x86_64 Linux, the following rules apply for C functions (specified in the [System V ABI]):
 
 [Calling conventions]: https://en.wikipedia.org/wiki/Calling_convention
-[System V ABI]: http://refspecs.linuxbase.org/elf/x86-64-abi-0.99.pdf
+[System V ABI]: http://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf
 
 - the first six integer arguments are passed in registers `rdi`, `rsi`, `rdx`, `rcx`, `r8`, `r9`
 - additional arguments are passed on the stack


### PR DESCRIPTION
I noticed that the link for the System V ABI was broken, and it was just due to a "-" instead of an "_". This pr should fix that.

I also want to say thanks so much for this project! It's incredibly inspiring. 