### PR TITLE
Update to the 2018 edition of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 name = "blog_os"
 version = "0.2.0"
+edition = "2018"
 
 [dependencies]
 bootloader = "0.3.4"

--- a/blog/content/second-edition/posts/01-freestanding-rust-binary/index.md
+++ b/blog/content/second-edition/posts/01-freestanding-rust-binary/index.md
@@ -52,10 +52,12 @@ By default, all Rust crates link the [standard library], which depends on the op
 We start by creating a new cargo application project. The easiest way to do this is through the command line:
 
 ```
-> cargo new blog_os --bin
+> cargo new blog_os --bin --edition 2018
 ```
 
-I named the project `blog_os`, but of course you can choose your own name. The `--bin` flag specifies that we want to create an executable binary (in contrast to a library). When we run the command, cargo creates the following directory structure for us:
+I named the project `blog_os`, but of course you can choose your own name. The `--bin` flag specifies that we want to create an executable binary (in contrast to a library) and the `--edition 2018` flag specifies that we want to use the [2018 edition] of Rust for our crate. When we run the command, cargo creates the following directory structure for us:
+
+[2018 edition]: https://rust-lang-nursery.github.io/edition-guide/rust-2018/index.html
 
 ```
 blog_os

--- a/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
@@ -332,12 +332,6 @@ Instead of writing our own bootloader, which is a project on its own, we use the
 bootloader = "0.3.4"
 ```
 
-```rust
-// in main.rs
-
-extern crate bootloader;
-```
-
 Adding the bootloader as dependency is not enough to actually create a bootable disk image. The problem is that we need to combine the bootloader with the kernel after it has been compiled, but cargo has no support for additional build steps after successful compilation (see [this issue][post-build script] for more information).
 
 [post-build script]: https://github.com/rust-lang/cargo/issues/545

--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -577,25 +577,29 @@ Now that we have a global writer, we can add a `println` macro that can be used 
 [`println!` macro]: https://doc.rust-lang.org/nightly/std/macro.println!.html
 
 ```rust
+#[macro_export]
 macro_rules! println {
     () => (print!("\n"));
-    ($fmt:expr) => (print!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+    ($($arg:tt)*) => (print!("{}\n", format_args!($($arg)*)));
 }
 ```
-Macros are defined through one or more rules, which are similar to `match` arms. The `println` macro has three rules: The first rule for is invocations without arguments (e.g `println!()`), the second rule is for invocations with a single argument (e.g. `println!("Hello")`) and the third rule is for invocations with additional parameters (e.g. `println!("{}{}", 4, 2)`).
 
-First line just prints a `\n` symbol which literally means "don't print anything, just break the line".
-Last two rules simply append a newline character (`\n`) to the format string and then invoke the [`print!` macro], which is defined as:
+Macros are defined through one or more rules, which are similar to `match` arms. The `println` macro has two rules: The first rule for is invocations without arguments (e.g `println!()`), which is expanded to `print!("\n)` and thus just prints a newline. the second rule is for invocations with parameters such as `println!("Hello")` or `println!("Number: {}", 4)`. It is also expanded to an invokation of the `print!` macro, passing all arguments and an additional newline `\n` at the end.
+
+The `#[macro_export]` attribute makes the available to the whole crate (not just the module it is defined) and external crates. It also places the macro at the crate root, which means that we have to import the macro through `use std::println` instead of `std::macros::println`.
+
+The [`print!` macro] is defined as:
 
 [`print!` macro]: https://doc.rust-lang.org/nightly/std/macro.print!.html
 
 ```rust
+#[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => ($crate::io::_print(format_args!($($arg)*)));
 }
 ```
-The macro expands to a call of the [`_print` function] in the `io` module. The [`$crate` variable] ensures that the macro also works from outside the `std` crate. For example, it expands to `::std` when it's used in other crates.
+
+The macro expands to a call of the [`_print` function] in the `io` module. The [`$crate` variable] ensures that the macro also works from outside the `std` crate by expanding to `std` when it's used in other crates.
 
 The [`format_args` macro] builds a [fmt::Arguments] type from the passed arguments, which is passed to `_print`. The [`_print` function] of libstd calls `print_to`, which is rather complicated because it supports different `Stdout` devices. We don't need that complexity since we just want to print to the VGA buffer.
 
@@ -604,36 +608,41 @@ The [`format_args` macro] builds a [fmt::Arguments] type from the passed argumen
 [`format_args` macro]: https://doc.rust-lang.org/nightly/std/macro.format_args.html
 [fmt::Arguments]: https://doc.rust-lang.org/nightly/core/fmt/struct.Arguments.html
 
-To print to the VGA buffer, we just copy the `println!` and `print!` macros, but modify them to use a `print` function:
+To print to the VGA buffer, we just copy the `println!` and `print!` macros, but modify them to use our own `_print` function:
 
 ```rust
 // in src/vga_buffer.rs
 
+#[macro_export]
 macro_rules! print {
-    ($($arg:tt)*) => ($crate::vga_buffer::print(format_args!($($arg)*)));
+    ($($arg:tt)*) => ($crate::vga_buffer::_print(format_args!($($arg)*)));
 }
 
+#[macro_export]
 macro_rules! println {
-    () => (print!("\n"));
-    ($fmt:expr) => (print!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+    () => ($crate::print!("\n"));
+    ($($arg:tt)*) => ($crate::print!("{}\n", format_args!($($arg)*)));
 }
 
-pub fn print(args: fmt::Arguments) {
+pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write;
     WRITER.lock().write_fmt(args).unwrap();
 }
 ```
-The `print` function locks our static `WRITER` and calls the `write_fmt` method on it. This method is from the `Write` trait, we need to import that trait. The additional `unwrap()` at the end panics if printing isn't successful. But since we always return `Ok` in `write_str`, that should not happen.
+
+The `_print` function locks our static `WRITER` and calls the `write_fmt` method on it. This method is from the `Write` trait, we need to import that trait. The additional `unwrap()` at the end panics if printing isn't successful. But since we always return `Ok` in `write_str`, that should not happen.
+
+We also add the `#[macro_export]` attribute to both macros to make them available everywhere in our crate. Note that this places the macros in the root namespace of the crate, so importing them via `use crate::vga_buffer::println` does not work. Instead, we have to do `use crate::println`.
+
+One thing that we changed from the original definitions is that we prefixed the invocations of the `print!` macro with `$crate` too. This ensures that we don't need to have to import the `print!` macro too if we only want to use `println`.
 
 ### Hello World using `println`
-To use `println` in `main.rs`, we need to import the macros of the VGA buffer module first. Therefore we add a `#[macro_use]` attribute to the module declaration:
+Now we can use `println` in our `_start` function:
 
 ```rust
 // in src/main.rs
 
-#[macro_use]
-mod vga_buffer;
+use crate::println;
 
 #[no_mangle]
 pub extern "C" fn _start() {
@@ -643,7 +652,7 @@ pub extern "C" fn _start() {
 }
 ```
 
-Since we imported the macros at crate level, they are available in all modules and thus provide an easy and safe interface to the VGA buffer.
+We have to explicitly import the `println` macro in order to use it. This is different from the standard library where the `println` macro is implicitly imported. Note that the macros live directly under the crate root (i.e. `crate::println` instead of `crate::vga_buffer::println`) because of the `#[macro_export]` attribute.
 
 As expected, we now see a _“Hello World!”_ on the screen:
 

--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -565,7 +565,7 @@ macro_rules! println {
 }
 ```
 
-Macros are defined through one or more rules, which are similar to `match` arms. The `println` macro has two rules: The first rule for is invocations without arguments (e.g `println!()`), which is expanded to `print!("\n)` and thus just prints a newline. the second rule is for invocations with parameters such as `println!("Hello")` or `println!("Number: {}", 4)`. It is also expanded to an invokation of the `print!` macro, passing all arguments and an additional newline `\n` at the end.
+Macros are defined through one or more rules, which are similar to `match` arms. The `println` macro has two rules: The first rule for is invocations without arguments (e.g `println!()`), which is expanded to `print!("\n)` and thus just prints a newline. the second rule is for invocations with parameters such as `println!("Hello")` or `println!("Number: {}", 4)`. It is also expanded to an invocation of the `print!` macro, passing all arguments and an additional newline `\n` at the end.
 
 The `#[macro_export]` attribute makes the available to the whole crate (not just the module it is defined) and external crates. It also places the macro at the crate root, which means that we have to import the macro through `use std::println` instead of `std::macros::println`.
 

--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -285,14 +285,6 @@ The `0.2.3` is the [semantic] version number. For more information, see the [Spe
 [semantic]: http://semver.org/
 [Specifying Dependencies]: http://doc.crates.io/specifying-dependencies.html
 
-Now we've declared that our project depends on the `volatile` crate and are able to import it in `src/main.rs`:
-
-```rust
-// in src/main.rs
-
-extern crate volatile;
-```
-
 Let's use it to make writes to the VGA buffer volatile. We update our `Buffer` type as follows:
 
 ```rust
@@ -475,12 +467,6 @@ The one-time initialization of statics with non-const functions is a common prob
 
 Let's add the `lazy_static` crate to our project:
 
-```rust
-// in src/main.rs
-
-extern crate lazy_static;
-```
-
 ```toml
 # in Cargo.toml
 
@@ -530,11 +516,6 @@ To use a spinning mutex, we can add the [spin crate] as a dependency:
 # in Cargo.toml
 [dependencies]
 spin = "0.4.9"
-```
-
-```rust
-// in src/main.rs
-extern crate spin;
 ```
 
 Then we can use the spinning Mutex to add safe [interior mutability] to our static `WRITER`:

--- a/blog/content/second-edition/posts/04-unit-testing/index.md
+++ b/blog/content/second-edition/posts/04-unit-testing/index.md
@@ -111,13 +111,13 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 The test framework seems to work as intended. We don't have any tests yet, but we already get a test result summary.
 
 ### Silencing the Warnings
-We get a few warnings about unused items, because we no longer compile our `_start` function. To silence such unused code warnings, we can add the following to the top of our `main.rs`:
+We get a few warnings about unused imports, because we no longer compile our `_start` function. To silence such unused code warnings, we can add the following to the top of our `main.rs`:
 
 ```
-#![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
+#![cfg_attr(test, allow(unused_imports))]
 ```
 
-Like before, the `cfg_attr` attribute sets the passed attribute if the passed condition holds. Here, we set the `allow(…)` attribute when compiling in test mode. We use the `allow` attribute to disable warnings for the `dead_code`, `unused_macro`, and `unused_import` _lints_.
+Like before, the `cfg_attr` attribute sets the passed attribute if the passed condition holds. Here, we set the `allow(…)` attribute when compiling in test mode. We use the `allow` attribute to disable warnings for the `unused_import` _lint_.
 
 Lints are classes of warnings, for example `dead_code` for unused code or `missing-docs` for missing documentation. Lints can be set to four different states:
 
@@ -131,14 +131,12 @@ Some lints are `allow` by default (such as `missing-docs`), others are `warn` by
 [clippy]: https://github.com/rust-lang-nursery/rust-clippy
 
 ### Including the Standard Library
-Unit tests run on the host machine, so it's possible to use the complete standard library inside them. To link the standard library in test mode, we can add the following to our `main.rs`:
+Unit tests run on the host machine, so it's possible to use the complete standard library inside them. To link the standard library in test mode, we can make the `#![no_std]` attribute conditional through `cfg_attr` too:
 
-```rust
-#[cfg(test)]
-extern crate std;
+```diff
+-#![no_std]
++#![cfg_attr(not(test), no_std)]
 ```
-
-Rust knows where to find the `std` crate, so no modification to the `Cargo.toml` is required.
 
 ## Testing the VGA Module
 Now that we have set up the test framework, we can add a first unit test for our `vga_buffer` module:

--- a/blog/content/second-edition/posts/04-unit-testing/index.md
+++ b/blog/content/second-edition/posts/04-unit-testing/index.md
@@ -244,17 +244,9 @@ To use that crate, we add the following to our `Cargo.toml`:
 array-init = "0.0.3"
 ```
 
-Note that we're using the [`dev-dependencies`] table instead of the `dependencies` table, because we only need the crate for `cargo test` and not for a normal build. Consequently, we also add a `#[cfg(test)]` attribute to the `extern crate` declaration in `main.rs`:
+Note that we're using the [`dev-dependencies`] table instead of the `dependencies` table, because we only need the crate for `cargo test` and not for a normal build.
 
 [`dev-dependencies`]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies
-
-
-```rust
-// in main.rs
-
-#[cfg(test)]
-extern crate array_init;
-```
 
 Now we can fix our `construct_buffer` function:
 

--- a/blog/content/second-edition/posts/05-integration-tests/index.md
+++ b/blog/content/second-edition/posts/05-integration-tests/index.md
@@ -66,12 +66,6 @@ We will use the [`uart_16550`] crate to initialize the UART and send data over t
 uart_16550 = "0.1.0"
 ```
 
-```rust
-// in src/main.rs
-
-extern crate uart_16550;
-```
-
 The `uart_16550` crate contains a `SerialPort` struct that represents the UART registers, but we still need to construct an instance of it ourselves. For that we create a new `serial` module with the following content:
 
 ```rust
@@ -209,8 +203,6 @@ x86_64 = "0.2.8"
 
 ```rust
 // in src/main.rs
-
-extern crate x86_64;
 
 pub unsafe fn exit_qemu() {
     use x86_64::instructions::port::Port;
@@ -376,16 +368,6 @@ Cargo supports hybrid projects that are both a library and a binary. We only nee
 
 #![cfg_attr(not(test), no_std)] // don't link the Rust standard library
 
-extern crate bootloader;
-extern crate spin;
-extern crate volatile;
-extern crate lazy_static;
-extern crate uart_16550;
-extern crate x86_64;
-
-#[cfg(test)]
-extern crate array_init;
-
 // NEW: We need to add `pub` here to make them accessible from the outside
 pub mod vga_buffer;
 pub mod serial;
@@ -404,9 +386,6 @@ pub unsafe fn exit_qemu() {
 #![no_std] // don't link the Rust standard library
 #![cfg_attr(not(test), no_main)] // disable all Rust-level entry points
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
-
-// NEW: Add the library as dependency (same crate name as executable)
-extern crate blog_os;
 
 use core::panic::PanicInfo;
 use blog_os::println;
@@ -430,7 +409,7 @@ fn panic(info: &PanicInfo) -> ! {
 }
 ```
 
-So we move everything except `_start` and `panic` to `lib.rs`, make the `vga_buffer` and `serial` modules public, and add an `extern crate` definition to our `main.rs`. Everything should work exactly as before, including `bootimage run` and `cargo test`.
+So we move everything except `_start` and `panic` to `lib.rs` and make the `vga_buffer` and `serial` modules public. Everything should work exactly as before, including `bootimage run` and `cargo test`.
 
 ### Test Basic Boot
 
@@ -442,9 +421,6 @@ We are finally able to create our first integration test executable. We start si
 #![no_std] // don't link the Rust standard library
 #![cfg_attr(not(test), no_main)] // disable all Rust-level entry points
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
-
-// add the library as dependency (same crate name as executable)
-extern crate blog_os;
 
 use core::panic::PanicInfo;
 use blog_os::{exit_qemu, serial_println};
@@ -506,8 +482,6 @@ To test that our panic handler is really invoked on a panic, we create a `test-p
 #![no_std]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
-
-extern crate blog_os;
 
 use core::panic::PanicInfo;
 use blog_os::{exit_qemu, serial_println};

--- a/blog/content/second-edition/posts/05-integration-tests/index.md
+++ b/blog/content/second-edition/posts/05-integration-tests/index.md
@@ -97,6 +97,7 @@ Like with the [VGA text buffer][vga lazy-static], we use `lazy_static` and a spi
 To make the serial port easily usable, we add `serial_print!` and `serial_println!` macros:
 
 ```rust
+#[doc(hidden)]
 pub fn _print(args: ::core::fmt::Arguments) {
     use core::fmt::Write;
     SERIAL1.lock().write_fmt(args).expect("Printing to serial failed");

--- a/blog/content/second-edition/posts/05-integration-tests/index.md
+++ b/blog/content/second-edition/posts/05-integration-tests/index.md
@@ -106,7 +106,7 @@ pub fn _print(args: ::core::fmt::Arguments) {
 #[macro_export]
 macro_rules! serial_print {
     ($($arg:tt)*) => {
-        $crate::serial::print(format_args!($($arg)*));
+        $crate::serial::_print(format_args!($($arg)*));
     };
 }
 

--- a/blog/content/second-edition/posts/08-hardware-interrupts/index.md
+++ b/blog/content/second-edition/posts/08-hardware-interrupts/index.md
@@ -247,6 +247,7 @@ We can already provoke a deadlock in our kernel. Remember, our `println` macro c
 
 […]
 
+#[doc(hidden)]
 pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write;
     WRITER.lock().write_fmt(args).unwrap();
@@ -302,6 +303,7 @@ To avoid this deadlock, we can disable interrupts as long as the `Mutex` is lock
 
 /// Prints the given formatted string to the VGA text buffer
 /// through the global `WRITER` instance.
+#[doc(hidden)]
 pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write;
     use x86_64::instructions::interrupts;   // new
@@ -322,6 +324,7 @@ We can apply the same change to our serial printing function to ensure that no d
 ```rust
 // in src/serial.rs
 
+#[doc(hidden)]
 pub fn _print(args: ::core::fmt::Arguments) {
     use core::fmt::Write;
     use x86_64::instructions::interrupts;       // new

--- a/blog/content/second-edition/posts/08-hardware-interrupts/index.md
+++ b/blog/content/second-edition/posts/08-hardware-interrupts/index.md
@@ -85,12 +85,6 @@ To add the crate as dependency, we add the following to our project:
 pic8259_simple = "0.1.1"
 ```
 
-```rust
-// in src/lib.rs
-
-extern crate pic8259_simple;
-```
-
 The main abstraction provided by the crate is the [`ChainedPics`] struct that represents the primary/secondary PIC layout we saw above. It is designed to be used in the following way:
 
 [`ChainedPics`]: https://docs.rs/pic8259_simple/0.1.1/pic8259_simple/struct.ChainedPics.html
@@ -541,12 +535,6 @@ Translating the other keys works in the same way. Fortunately there is a crate n
 
 [dependencies]
 pc-keyboard = "0.3.1"
-```
-
-```rust
-// in src/lib.rs
-
-extern crate pc_keyboard;
 ```
 
 Now we can use this crate to rewrite our `keyboard_interrupt_handler`:

--- a/blog/content/second-edition/posts/08-hardware-interrupts/index.md
+++ b/blog/content/second-edition/posts/08-hardware-interrupts/index.md
@@ -253,7 +253,7 @@ We can already provoke a deadlock in our kernel. Remember, our `println` macro c
 
 […]
 
-pub fn print(args: fmt::Arguments) {
+pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write;
     WRITER.lock().write_fmt(args).unwrap();
 }
@@ -308,7 +308,7 @@ To avoid this deadlock, we can disable interrupts as long as the `Mutex` is lock
 
 /// Prints the given formatted string to the VGA text buffer
 /// through the global `WRITER` instance.
-pub fn print(args: fmt::Arguments) {
+pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write;
     use x86_64::instructions::interrupts;   // new
 
@@ -328,7 +328,7 @@ We can apply the same change to our serial printing function to ensure that no d
 ```rust
 // in src/serial.rs
 
-pub fn print(args: ::core::fmt::Arguments) {
+pub fn _print(args: ::core::fmt::Arguments) {
     use core::fmt::Write;
     use x86_64::instructions::interrupts;       // new
 

--- a/blog/content/second-edition/posts/08-hardware-interrupts/index.md
+++ b/blog/content/second-edition/posts/08-hardware-interrupts/index.md
@@ -238,7 +238,7 @@ The hardware timer that we use is called the _Progammable Interval Timer_ or PIT
 
 We now have a form of concurrency in our kernel: The timer interrupts occur asynchronously, so they can interrupt our `_start` function at any time. Fortunately Rust's ownership system prevents many types of concurrency related bugs at compile time. One notable exception are deadlocks. Deadlocks occur if a thread tries to aquire a lock that will never become free. Thus the thread hangs indefinitely.
 
-We can already provoke a deadlock in our kernel. Remember, our `println` macro calls the `vga_buffer::print` function, which [locks a global `WRITER`][vga spinlock] using a spinlock:
+We can already provoke a deadlock in our kernel. Remember, our `println` macro calls the `vga_buffer::_print` function, which [locks a global `WRITER`][vga spinlock] using a spinlock:
 
 [vga spinlock]: ./second-edition/posts/03-vga-text-buffer/index.md#spinlocks
 

--- a/src/bin/test-basic-boot.rs
+++ b/src/bin/test-basic-boot.rs
@@ -2,11 +2,7 @@
 #![cfg_attr(not(test), no_main)] // disable all Rust-level entry points
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
 
-// add the library as dependency (same crate name as executable)
-#[macro_use]
-extern crate blog_os;
-
-use blog_os::exit_qemu;
+use blog_os::{exit_qemu, serial_println};
 use core::panic::PanicInfo;
 
 /// This function is the entry point, since the linker looks for a function

--- a/src/bin/test-exception-breakpoint.rs
+++ b/src/bin/test-exception-breakpoint.rs
@@ -3,12 +3,7 @@
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
 
-#[macro_use]
-extern crate blog_os;
-extern crate x86_64;
-extern crate lazy_static;
-
-use blog_os::exit_qemu;
+use blog_os::{exit_qemu, serial_println};
 use core::panic::PanicInfo;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use lazy_static::lazy_static;

--- a/src/bin/test-exception-double-fault-stack-overflow.rs
+++ b/src/bin/test-exception-double-fault-stack-overflow.rs
@@ -3,12 +3,7 @@
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
 
-#[macro_use]
-extern crate blog_os;
-extern crate x86_64;
-extern crate lazy_static;
-
-use blog_os::exit_qemu;
+use blog_os::{exit_qemu, serial_println};
 use core::panic::PanicInfo;
 use lazy_static::lazy_static;
 

--- a/src/bin/test-panic.rs
+++ b/src/bin/test-panic.rs
@@ -2,10 +2,7 @@
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
 
-#[macro_use]
-extern crate blog_os;
-
-use blog_os::exit_qemu;
+use blog_os::{exit_qemu, serial_println};
 use core::panic::PanicInfo;
 
 #[cfg(not(test))]

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -4,7 +4,7 @@
 // problem we skip compilation of this module on Windows.
 #![cfg(not(windows))]
 
-use gdt;
+use crate::gdt;
 use pic8259_simple::ChainedPics;
 use spin;
 use x86_64::structures::idt::{ExceptionStackFrame, InterruptDescriptorTable};
@@ -48,7 +48,7 @@ extern "x86-interrupt" fn double_fault_handler(
     stack_frame: &mut ExceptionStackFrame,
     _error_code: u64,
 ) {
-    use hlt_loop;
+    use crate::hlt_loop;
 
     println!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
     hlt_loop();

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -4,7 +4,7 @@
 // problem we skip compilation of this module on Windows.
 #![cfg(not(windows))]
 
-use crate::gdt;
+use crate::{gdt, print, println};
 use pic8259_simple::ChainedPics;
 use spin;
 use x86_64::structures::idt::{ExceptionStackFrame, InterruptDescriptorTable};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(test), no_std)] // don't link the Rust standard library
 #![feature(abi_x86_interrupt)]
 
-#[macro_use]
 pub mod vga_buffer;
 pub mod gdt;
 pub mod interrupts;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,5 @@
-#![no_std] // don't link the Rust standard library
+#![cfg_attr(not(test), no_std)] // don't link the Rust standard library
 #![feature(abi_x86_interrupt)]
-
-extern crate bootloader;
-extern crate spin;
-extern crate volatile;
-extern crate lazy_static;
-extern crate pic8259_simple;
-extern crate uart_16550;
-extern crate x86_64;
-extern crate pc_keyboard;
-
-#[cfg(test)]
-extern crate array_init;
-#[cfg(test)]
-extern crate std;
 
 #[macro_use]
 pub mod vga_buffer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![no_std] // don't link the Rust standard library
 #![cfg_attr(not(test), no_main)] // disable all Rust-level entry points
-#![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
+#![cfg_attr(test, allow(unused_imports))]
 
 use core::panic::PanicInfo;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,9 @@
 #![cfg_attr(not(test), no_main)] // disable all Rust-level entry points
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
 
-#[macro_use]
-extern crate blog_os;
-extern crate x86_64;
-
 use core::panic::PanicInfo;
+
+use blog_os::println;
 
 /// This function is the entry point, since the linker looks for a function
 /// named `_start` by default.

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -10,7 +10,7 @@ lazy_static! {
     };
 }
 
-pub fn print(args: ::core::fmt::Arguments) {
+pub fn _print(args: ::core::fmt::Arguments) {
     use core::fmt::Write;
     use x86_64::instructions::interrupts;
 
@@ -26,7 +26,7 @@ pub fn print(args: ::core::fmt::Arguments) {
 #[macro_export]
 macro_rules! serial_print {
     ($($arg:tt)*) => {
-        $crate::serial::print(format_args!($($arg)*));
+        $crate::serial::_print(format_args!($($arg)*));
     };
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -10,6 +10,7 @@ lazy_static! {
     };
 }
 
+#[doc(hidden)]
 pub fn _print(args: ::core::fmt::Arguments) {
     use core::fmt::Write;
     use x86_64::instructions::interrupts;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -33,7 +33,7 @@ macro_rules! serial_print {
 /// Prints to the host through the serial interface, appending a newline.
 #[macro_export]
 macro_rules! serial_println {
-    () => (serial_print!("\n"));
-    ($fmt:expr) => (serial_print!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => (serial_print!(concat!($fmt, "\n"), $($arg)*));
+    () => ($crate::serial_print!("\n"));
+    ($fmt:expr) => ($crate::serial_print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => ($crate::serial_print!(concat!($fmt, "\n"), $($arg)*));
 }

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -157,9 +157,9 @@ macro_rules! print {
 /// Like the `print!` macro in the standard library, but prints to the VGA text buffer.
 #[macro_export]
 macro_rules! println {
-    () => (print!("\n"));
-    ($fmt:expr) => (print!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+    () => ($crate::print!("\n"));
+    ($fmt:expr) => ($crate::print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => ($crate::print!(concat!($fmt, "\n"), $($arg)*));
 }
 
 /// Prints the given formatted string to the VGA text buffer through the global `WRITER` instance.

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -154,12 +154,11 @@ macro_rules! print {
     ($($arg:tt)*) => ($crate::vga_buffer::_print(format_args!($($arg)*)));
 }
 
-/// Like the `print!` macro in the standard library, but prints to the VGA text buffer.
+/// Like the `println!` macro in the standard library, but prints to the VGA text buffer.
 #[macro_export]
 macro_rules! println {
     () => ($crate::print!("\n"));
-    ($fmt:expr) => ($crate::print!(concat!($fmt, "\n")));
-    ($fmt:expr, $($arg:tt)*) => ($crate::print!(concat!($fmt, "\n"), $($arg)*));
+    ($($arg:tt)*) => ($crate::print!("{}\n", format_args!($($arg)*)));
 }
 
 /// Prints the given formatted string to the VGA text buffer through the global `WRITER` instance.

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -162,6 +162,7 @@ macro_rules! println {
 }
 
 /// Prints the given formatted string to the VGA text buffer through the global `WRITER` instance.
+#[doc(hidden)]
 pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write;
     use x86_64::instructions::interrupts;

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -151,7 +151,7 @@ impl fmt::Write for Writer {
 /// Like the `print!` macro in the standard library, but prints to the VGA text buffer.
 #[macro_export]
 macro_rules! print {
-    ($($arg:tt)*) => ($crate::vga_buffer::print(format_args!($($arg)*)));
+    ($($arg:tt)*) => ($crate::vga_buffer::_print(format_args!($($arg)*)));
 }
 
 /// Like the `print!` macro in the standard library, but prints to the VGA text buffer.
@@ -163,7 +163,7 @@ macro_rules! println {
 }
 
 /// Prints the given formatted string to the VGA text buffer through the global `WRITER` instance.
-pub fn print(args: fmt::Arguments) {
+pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write;
     use x86_64::instructions::interrupts;
 


### PR DESCRIPTION
This updates the blog to use the upcoming [2018 edition](https://rust-lang-nursery.github.io/edition-guide/rust-2018/index.html) of Rust, which is currently in beta and already the default on nightly. It changes a few local import paths (now with a `crate::` prefix) and removes all `extern crate` definitions and `macro_use` attributes.

This PR changes a lot of code across all posts, so there might be some things in the posts that I forgot to update. Please let me know if you see anything! [Preview of the changes](https://rust-2018--blog-os.netlify.com/)

Fixes #499 
Fixes #500