### PR TITLE
[CI] Also test for *.exe executables on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,11 @@ os:
   - windows
 
 cache:
-  branch: bash
-  cargo: true
+  # Fix absolute extraction - https://github.com/travis-ci/casher/pull/38
+  branch: 46c41ee208def16781fe4075283b70e1dbfe70ae
   directories:
     - ${TRAVIS_HOME}/Library/Caches/Homebrew
+    - ${TRAVIS_HOME}/.cargo
 
 addons:
   apt:
@@ -46,7 +47,7 @@ install:
 before_script:
   - rustup component add rust-src
   - (test -x ${TRAVIS_HOME}/.cargo/bin/cargo-install-latest || test -x ${TRAVIS_HOME}/.cargo/bin/cargo-install-latest.exe || cargo install cargo-install-latest)
-  - cargo install-latest cargo-xbuild bootimage
+  - cargo install-latest cargo-xbuild bootimage cargo-cache
   - ls ${TRAVIS_HOME}/.cargo/bin
   - cargo install --list
 
@@ -55,3 +56,4 @@ script:
   - bootimage build
   - cargo test
   - bootimage test
+  - cargo cache --autoclean

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,11 @@ os:
   - osx
   - windows
 
-cache: cargo
+cache:
+  branch: bash
+  cargo: true
+  directories:
+    - ${TRAVIS_HOME}/Library/Caches/Homebrew
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ before_script:
   - ls ${TRAVIS_HOME}/.cargo/bin
   - cargo install --list
 
+
 script:
   - bootimage build
   - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,8 @@ install:
 
 before_script:
   - rustup component add rust-src
-  - (test -x $HOME/.cargo/bin/cargo-update-installed || test -x $HOME/.cargo/bin/cargo-update-installed.exe || cargo install cargo-update-installed)
-  - (test -x $HOME/.cargo/bin/cargo-xbuild || test -x $HOME/.cargo/bin/cargo-xbuild.exe || cargo install cargo-xbuild)
-  - (test -x $HOME/.cargo/bin/bootimage || test -x $HOME/.cargo/bin/bootimage.exe || cargo install bootimage)
-  - (test -x $HOME/.cargo/bin/cargo-cache || test -x $HOME/.cargo/bin/cargo-cache.exe || cargo install cargo-cache)
-  - cargo update-installed
+  - (test -x $HOME/.cargo/bin/cargo-install-latest || test -x $HOME/.cargo/bin/cargo-install-latest.exe || cargo install cargo-install-latest)
+  - cargo install-latest cargo-xbuild bootimage cargo-cache
 
 script:
   - bootimage build

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ os:
 
 cache:
   directories:
-    - $HOME/.cargo
-    - $HOME/Library/Caches/Homebrew
+    - ${TRAVIS_HOME}/.cargo
+    - ${TRAVIS_HOME}/Library/Caches/Homebrew
 
 addons:
   apt:
@@ -38,15 +38,15 @@ addons:
       - qemu
 
 install:
-  - ls $HOME/.cargo/bin
+  - ls ${TRAVIS_HOME}/.cargo/bin
   - cargo install --list
   - if [ $TRAVIS_OS_NAME = windows ]; then choco install qemu; export PATH="/c/Program Files/qemu:$PATH"; fi
 
 before_script:
   - rustup component add rust-src
-  - (test -x $HOME/.cargo/bin/cargo-install-latest || test -x $HOME/.cargo/bin/cargo-install-latest.exe || cargo install cargo-install-latest)
+  - (test -x ${TRAVIS_HOME}/.cargo/bin/cargo-install-latest || test -x ${TRAVIS_HOME}/.cargo/bin/cargo-install-latest.exe || cargo install cargo-install-latest)
   - cargo install-latest cargo-xbuild bootimage cargo-cache
-  - ls $HOME/.cargo/bin
+  - ls ${TRAVIS_HOME}/.cargo/bin
   - cargo install --list
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,7 @@ os:
   - osx
   - windows
 
-cache:
-  directories:
-    - ${TRAVIS_HOME}/.cargo
-    - ${TRAVIS_HOME}/Library/Caches/Homebrew
+cache: cargo
 
 addons:
   apt:
@@ -45,7 +42,7 @@ install:
 before_script:
   - rustup component add rust-src
   - (test -x ${TRAVIS_HOME}/.cargo/bin/cargo-install-latest || test -x ${TRAVIS_HOME}/.cargo/bin/cargo-install-latest.exe || cargo install cargo-install-latest)
-  - cargo install-latest cargo-xbuild bootimage cargo-cache
+  - cargo install-latest cargo-xbuild bootimage
   - ls ${TRAVIS_HOME}/.cargo/bin
   - cargo install --list
 
@@ -53,4 +50,3 @@ script:
   - bootimage build
   - cargo test
   - bootimage test
-  - cargo cache --autoclean

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ install:
 
 before_script:
   - rustup component add rust-src
-  - (test -x $HOME/.cargo/bin/cargo-update-installed || cargo install cargo-update-installed)
-  - (test -x $HOME/.cargo/bin/cargo-xbuild || cargo install cargo-xbuild)
-  - (test -x $HOME/.cargo/bin/bootimage || cargo install bootimage)
-  - (test -x $HOME/.cargo/bin/cargo-cache || cargo install cargo-cache)
+  - (test -x $HOME/.cargo/bin/cargo-update-installed || test -x $HOME/.cargo/bin/cargo-update-installed.exe || cargo install cargo-update-installed)
+  - (test -x $HOME/.cargo/bin/cargo-xbuild || test -x $HOME/.cargo/bin/cargo-xbuild.exe || cargo install cargo-xbuild)
+  - (test -x $HOME/.cargo/bin/bootimage || test -x $HOME/.cargo/bin/bootimage.exe || cargo install bootimage)
+  - (test -x $HOME/.cargo/bin/cargo-cache || test -x $HOME/.cargo/bin/cargo-cache.exe || cargo install cargo-cache)
   - cargo update-installed
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,16 @@ addons:
       - qemu
 
 install:
+  - ls $HOME/.cargo/bin
+  - cargo install --list
   - if [ $TRAVIS_OS_NAME = windows ]; then choco install qemu; export PATH="/c/Program Files/qemu:$PATH"; fi
 
 before_script:
   - rustup component add rust-src
   - (test -x $HOME/.cargo/bin/cargo-install-latest || test -x $HOME/.cargo/bin/cargo-install-latest.exe || cargo install cargo-install-latest)
   - cargo install-latest cargo-xbuild bootimage cargo-cache
+  - ls $HOME/.cargo/bin
+  - cargo install --list
 
 script:
   - bootimage build


### PR DESCRIPTION
This avoids reinstalling the `.cargo/bin` tools on Windows.