### PR TITLE
don't require nightly compiler from freestanding binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ cache:
     - $HOME/.cargo
 
 script:
-  - cargo rustc -- -Z pre-link-arg=-nostartfiles
+  - cargo rustc -- -Clink-arg=-nostartfiles

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This repository contains the source code for the [A Freestanding Rust Binary][po
 
 ## Building
 
-You need a nightly Rust compiler. To build the project on Linux, run:
+To build the project on Linux, run:
 
 ```
-cargo rustc -- -Z pre-link-arg=-nostartfiles
+cargo rustc -- -Clink-arg=-nostartfiles
 ```
 
 The entry point and the build command differ slightly on macOS and Windows. See the [post] for more information.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,5 +41,5 @@ steps:
   displayName: 'Print Rust Version'
   continueOnError: true
 
-- script: cargo rustc -- -Z pre-link-arg=-nostartfiles
+- script: cargo rustc -- -Clink-arg=-nostartfiles
   displayName: 'Build'

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly


### PR DESCRIPTION
adding linker args can be done with the stable `-Clink-arg`.

the difference with `-Zpre-link-arg` is that the args are appended instead of prepended. is that distinction important in this case?