### PR TITLE
encapsulate the hardware interrupts' indexes + minor corrections

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -15,13 +15,13 @@ pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
 
 pub mod interrupt_indexes {
     #[derive(Debug)]
-	#[repr(u8)]
-	pub enum Hardware {
-		Timer = super::PIC_1_OFFSET,
-		Keyboard,
-	}
-	pub fn as_u8(interrupt: Hardware) -> u8 { interrupt as u8 }
-	pub fn as_usize(interrupt: Hardware) -> usize { usize::from(as_u8(interrupt)) }
+    #[repr(u8)]
+    pub enum Hardware {
+        Timer = super::PIC_1_OFFSET,
+        Keyboard,
+    }
+    pub fn as_u8(interrupt: Hardware) -> u8 { interrupt as u8 }
+    pub fn as_usize(interrupt: Hardware) -> usize { usize::from(as_u8(interrupt)) }
 }
 
 pub static PICS: spin::Mutex<ChainedPics> =
@@ -36,9 +36,9 @@ lazy_static! {
                 .set_handler_fn(double_fault_handler)
                 .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
         }
-	    use self::interrupt_indexes::*;
-	    idt[as_usize(Hardware::Timer)].set_handler_fn(timer_interrupt_handler);
-	    idt[as_usize(Hardware::Keyboard)].set_handler_fn(keyboard_interrupt_handler);
+        use self::interrupt_indexes::*;
+        idt[as_usize(Hardware::Timer)].set_handler_fn(timer_interrupt_handler);
+        idt[as_usize(Hardware::Keyboard)].set_handler_fn(keyboard_interrupt_handler);
         idt
     };
 }

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -15,12 +15,12 @@ pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
-pub enum HardwareInterruptIndexes {
+pub enum InterruptIndex {
     Timer = PIC_1_OFFSET,
     Keyboard,
 }
 
-impl HardwareInterruptIndexes {
+impl InterruptIndex {
     fn as_u8(self) -> u8 { self as u8 }
     fn as_usize(self) -> usize { usize::from(self.as_u8()) }
 }
@@ -37,9 +37,8 @@ lazy_static! {
                 .set_handler_fn(double_fault_handler)
                 .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
         }
-        use self::HardwareInterruptIndexes::*;
-        idt[Timer.as_usize()].set_handler_fn(timer_interrupt_handler);
-        idt[Keyboard.as_usize()].set_handler_fn(keyboard_interrupt_handler);
+        idt[InterruptIndex::Timer.as_usize()].set_handler_fn(timer_interrupt_handler);
+        idt[InterruptIndex::Keyboard.as_usize()].set_handler_fn(keyboard_interrupt_handler);
         idt
     };
 }
@@ -62,7 +61,7 @@ extern "x86-interrupt" fn double_fault_handler(
 
 extern "x86-interrupt" fn timer_interrupt_handler(_stack_frame: &mut ExceptionStackFrame) {
     print!(".");
-    unsafe { PICS.lock().notify_end_of_interrupt(HardwareInterruptIndexes::Timer.as_u8()) }
+    unsafe { PICS.lock().notify_end_of_interrupt(InterruptIndex::Timer.as_u8()) }
 }
 
 extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: &mut ExceptionStackFrame) {
@@ -88,5 +87,5 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: &mut Exceptio
         }
     }
 
-    unsafe { PICS.lock().notify_end_of_interrupt(HardwareInterruptIndexes::Keyboard.as_u8()) }
+    unsafe { PICS.lock().notify_end_of_interrupt(InterruptIndex::Keyboard.as_u8()) }
 }

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -24,7 +24,7 @@ pub mod interrupt_indexes {
 	pub fn as_usize(interrupt: Hardware) -> usize { usize::from(as_u8(interrupt)) }
 }
 
-pub static PICS: spin::Mutex<ChainedPics``> =
+pub static PICS: spin::Mutex<ChainedPics> =
     spin::Mutex::new(unsafe { ChainedPics::new(PIC_1_OFFSET, PIC_2_OFFSET) });
 
 lazy_static! {
@@ -36,9 +36,9 @@ lazy_static! {
                 .set_handler_fn(double_fault_handler)
                 .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
         }
-		use self::interrupt_indexes::*;
-		idt[as_usize(Hardware::Timer)].set_handler_fn(timer_interrupt_handler);
-		idt[as_usize(Hardware::Keyboard)].set_handler_fn(keyboard_interrupt_handler);
+	use self::interrupt_indexes::*;
+	idt[as_usize(Hardware::Timer)].set_handler_fn(timer_interrupt_handler);
+	idt[as_usize(Hardware::Keyboard)].set_handler_fn(keyboard_interrupt_handler);
         idt
     };
 }
@@ -61,7 +61,7 @@ extern "x86-interrupt" fn double_fault_handler(
 
 extern "x86-interrupt" fn timer_interrupt_handler(_stack_frame: &mut ExceptionStackFrame) {
     print!(".");
-	use self::interrupt_indexes::*;
+    use self::interrupt_indexes::*;
 	unsafe { PICS.lock().notify_end_of_interrupt(as_u8(Hardware::Timer)) }
 }
 

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -14,7 +14,7 @@ pub const PIC_1_OFFSET: u8 = 32;
 pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
 
 pub mod interrupt_indexes {
-	#[derive(Debug)]
+    #[derive(Debug)]
 	#[repr(u8)]
 	pub enum Hardware {
 		Timer = super::PIC_1_OFFSET,
@@ -36,9 +36,9 @@ lazy_static! {
                 .set_handler_fn(double_fault_handler)
                 .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
         }
-	use self::interrupt_indexes::*;
-	idt[as_usize(Hardware::Timer)].set_handler_fn(timer_interrupt_handler);
-	idt[as_usize(Hardware::Keyboard)].set_handler_fn(keyboard_interrupt_handler);
+	    use self::interrupt_indexes::*;
+	    idt[as_usize(Hardware::Timer)].set_handler_fn(timer_interrupt_handler);
+	    idt[as_usize(Hardware::Keyboard)].set_handler_fn(keyboard_interrupt_handler);
         idt
     };
 }
@@ -62,11 +62,11 @@ extern "x86-interrupt" fn double_fault_handler(
 extern "x86-interrupt" fn timer_interrupt_handler(_stack_frame: &mut ExceptionStackFrame) {
     print!(".");
     use self::interrupt_indexes::*;
-	unsafe { PICS.lock().notify_end_of_interrupt(as_u8(Hardware::Timer)) }
+    unsafe { PICS.lock().notify_end_of_interrupt(as_u8(Hardware::Timer)) }
 }
 
 extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: &mut ExceptionStackFrame) {
-	use interrupt_indexes::*;
+    use interrupt_indexes::*;
     use pc_keyboard::{layouts, DecodedKey, Keyboard, ScancodeSet1};
     use spin::Mutex;
     use x86_64::instructions::port::Port;
@@ -89,5 +89,5 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: &mut Exceptio
         }
     }
 
-	unsafe { PICS.lock().notify_end_of_interrupt(as_u8(Hardware::Keyboard)) }
+    unsafe { PICS.lock().notify_end_of_interrupt(as_u8(Hardware::Keyboard)) }
 }

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -13,15 +13,16 @@ use x86_64::structures::idt::{ExceptionStackFrame, InterruptDescriptorTable};
 pub const PIC_1_OFFSET: u8 = 32;
 pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
 
-pub mod interrupt_indexes {
-    #[derive(Debug)]
-    #[repr(u8)]
-    pub enum Hardware {
-        Timer = super::PIC_1_OFFSET,
-        Keyboard,
-    }
-    pub fn as_u8(interrupt: Hardware) -> u8 { interrupt as u8 }
-    pub fn as_usize(interrupt: Hardware) -> usize { usize::from(as_u8(interrupt)) }
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum HardwareInterruptIndexes {
+    Timer = PIC_1_OFFSET,
+    Keyboard,
+}
+
+impl HardwareInterruptIndexes {
+    fn as_u8(self) -> u8 { self as u8 }
+    fn as_usize(self) -> usize { usize::from(self.as_u8()) }
 }
 
 pub static PICS: spin::Mutex<ChainedPics> =
@@ -36,9 +37,9 @@ lazy_static! {
                 .set_handler_fn(double_fault_handler)
                 .set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
         }
-        use self::interrupt_indexes::*;
-        idt[as_usize(Hardware::Timer)].set_handler_fn(timer_interrupt_handler);
-        idt[as_usize(Hardware::Keyboard)].set_handler_fn(keyboard_interrupt_handler);
+        use self::HardwareInterruptIndexes::*;
+        idt[Timer.as_usize()].set_handler_fn(timer_interrupt_handler);
+        idt[Keyboard.as_usize()].set_handler_fn(keyboard_interrupt_handler);
         idt
     };
 }
@@ -61,12 +62,10 @@ extern "x86-interrupt" fn double_fault_handler(
 
 extern "x86-interrupt" fn timer_interrupt_handler(_stack_frame: &mut ExceptionStackFrame) {
     print!(".");
-    use self::interrupt_indexes::*;
-    unsafe { PICS.lock().notify_end_of_interrupt(as_u8(Hardware::Timer)) }
+    unsafe { PICS.lock().notify_end_of_interrupt(HardwareInterruptIndexes::Timer.as_u8()) }
 }
 
 extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: &mut ExceptionStackFrame) {
-    use interrupt_indexes::*;
     use pc_keyboard::{layouts, DecodedKey, Keyboard, ScancodeSet1};
     use spin::Mutex;
     use x86_64::instructions::port::Port;
@@ -89,5 +88,5 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: &mut Exceptio
         }
     }
 
-    unsafe { PICS.lock().notify_end_of_interrupt(as_u8(Hardware::Keyboard)) }
+    unsafe { PICS.lock().notify_end_of_interrupt(HardwareInterruptIndexes::Keyboard.as_u8()) }
 }


### PR DESCRIPTION
I have changed the source code but I don't know how to reflect the changes on the blog.
This is the first time I contribute to something, I don't really know what I'm doing exactly.
I hope it does not only works for me, it would be nice if someone could clone my modifications locally to be sure it's actually working.
The first commit (9f6ea55) is the most important and the changes are precisely detailed in the commit description.