### PR TITLE
double-faults misspell fixed

### DIFF
--- a/blog/content/first-edition/posts/10-double-faults/index.md
+++ b/blog/content/first-edition/posts/10-double-faults/index.md
@@ -196,7 +196,7 @@ struct InterruptStackTable {
 }
 ```
 
-For each exception handler, we can choose an stack from the IST through the `options` field in the corresponding [IDT entry]. For example, we could use the first stack in the IST for our double fault handler. Then the CPU would automatically switch to this stack whenever a double fault occurs. This switch would happen before anything is pushed, so it would prevent the triple fault.
+For each exception handler, we can choose a stack from the IST through the `options` field in the corresponding [IDT entry]. For example, we could use the first stack in the IST for our double fault handler. Then the CPU would automatically switch to this stack whenever a double fault occurs. This switch would happen before anything is pushed, so it would prevent the triple fault.
 
 [IDT entry]: ./first-edition/posts/09-handling-exceptions/index.md#the-interrupt-descriptor-table
 

--- a/blog/content/second-edition/posts/07-double-faults/index.md
+++ b/blog/content/second-edition/posts/07-double-faults/index.md
@@ -192,7 +192,7 @@ struct InterruptStackTable {
 }
 ```
 
-For each exception handler, we can choose an stack from the IST through the `options` field in the corresponding [IDT entry]. For example, we could use the first stack in the IST for our double fault handler. Then the CPU would automatically switch to this stack whenever a double fault occurs. This switch would happen before anything is pushed, so it would prevent the triple fault.
+For each exception handler, we can choose a stack from the IST through the `options` field in the corresponding [IDT entry]. For example, we could use the first stack in the IST for our double fault handler. Then the CPU would automatically switch to this stack whenever a double fault occurs. This switch would happen before anything is pushed, so it would prevent the triple fault.
 
 [IDT entry]: ./second-edition/posts/06-cpu-exceptions/index.md#the-interrupt-descriptor-table
 


### PR DESCRIPTION
`an stack` -> `a stack`