### PR TITLE
Update CI build for rewrite of "A Freestanding Rust Binary"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,12 @@ strategy:
     linux:
       image_name: 'ubuntu-16.04'
       rustup_toolchain: stable
+    mac:
+      image_name: 'macos-10.13'
+      rustup_toolchain: stable
+    windows:
+      image_name: 'vs2017-win2016'
+      rustup_toolchain: stable
 
 pool:
   vmImage: $(image_name)
@@ -33,7 +39,15 @@ steps:
 - script: |
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOOLCHAIN
     echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
-  displayName: 'Install Rust'
+  condition: or(eq( variables['Agent.OS'], 'Linux' ),  eq( variables['Agent.OS'], 'Darwin' ))
+  displayName: 'Install Rust (Linux/macOS)'
+
+- script: |
+    curl -sSf -o rustup-init.exe https://win.rustup.rs
+    rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
+    echo ##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  displayName: 'Install Rust (Windows)'
 
 - script: |
     rustc -Vv
@@ -41,8 +55,23 @@ steps:
   displayName: 'Print Rust Version'
   continueOnError: true
 
-- script: cargo rustc -- -Clink-arg=-nostartfiles
-  displayName: 'Build'
+- script: rustup target add thumbv7em-none-eabihf
+  displayName: Add thumbv7em-none-eabihf Target
+
+- script: cargo build --target thumbv7em-none-eabihf
+  displayName: 'Build for thumbv7em-none-eabihf'
+
+- script: cargo rustc -- -C link-arg=-nostartfiles
+  condition: eq( variables['Agent.OS'], 'Linux' )
+  displayName: 'Build for Linux'
+
+- script: cargo rustc -- -C link-args="-e __start -static -nostartfiles"
+  condition: eq( variables['Agent.OS'], 'Darwin' )
+  displayName: 'Build for macOS'
+
+- script: cargo rustc -- -C link-args="/ENTRY:_start /SUBSYSTEM:console"
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  displayName: 'Build for Windows'
 
 - script: rustup component add rustfmt
   displayName: 'Install Rustfmt'


### PR DESCRIPTION
See https://github.com/phil-opp/blog_os/pull/577 for information about the rewrite.

This commit updates the azure pipelines CI script in the following way:

- build on all three OSs
- build for thumbv7em-none-eabihf