### PR TITLE
Add `.cargo/config` file to post-02 branch and update bootimage

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -73,4 +73,4 @@ before_test:
   - cargo install-latest cargo-xbuild bootimage
 
 test_script:
-  - bootimage build
+  - cargo bootimage

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -73,4 +73,5 @@ before_test:
   - cargo install-latest cargo-xbuild bootimage
 
 test_script:
+  - cargo xbuild
   - cargo bootimage

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[build]
+target = "x86_64-blog_os.json"
+
+[target.'cfg(target_os = "none")']
+runner = "bootimage runner"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,6 @@ before_script:
   - cargo install cargo-xbuild bootimage cargo-cache --debug -Z install-upgrade
 
 script:
+  - cargo xbuild
   - cargo bootimage
   - cargo cache --autoclean

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,8 @@ cache:
 
 before_script:
   - rustup component add rust-src llvm-tools-preview
-  - (test -x $HOME/.cargo/bin/cargo-install-latest || cargo install cargo-install-latest)
-  - cargo install-latest cargo-xbuild bootimage cargo-cache
+  - cargo install cargo-xbuild bootimage cargo-cache --debug -Z install-upgrade
 
 script:
-  - bootimage build
+  - cargo bootimage
   - cargo cache --autoclean

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,12 +22,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "blog_os"
 version = "0.1.0"
 dependencies = [
- "bootloader 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bootloader 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bootloader"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -215,7 +215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum array-init 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
 "checksum bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
-"checksum bootloader 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2735a1e3ddf16e6832fff86db617778dd3cecd5804fc8c2f20f448750d4c989c"
+"checksum bootloader 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8654b1ebbd38d2a8687a451ad53466d01b5edc9d75ec63d676525a6103d77151"
 "checksum fixedvec 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7c6c16d316ccdac21a4dd648e314e76facbbaf316e83ca137d0857a9c07419d0"
 "checksum font8x8 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b81d84c3c978af7d05d31a2198af4b9ba956d819d15d8f6d58fc150e33f8dc1f"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.5.1"
+bootloader = "0.6.0"
 
 [profile.dev]
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ cargo install cargo-xbuild bootimage
 Then you can build the project by running:
 
 ```
-bootimage build
+cargo xbuild
+```
+
+To create a bootable disk image, run:
+
+```
+cargo bootimage
 ```
 
 This creates a bootable disk image in the `target/x86_64-blog_os/debug` directory.
@@ -33,7 +39,7 @@ You can run the disk image in [QEMU] through:
 [QEMU]: https://www.qemu.org/
 
 ```
-bootimage run
+cargo xrun
 ```
 
 Of course [QEMU] needs to be installed for this.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,12 +52,10 @@ steps:
 - script: rustup component add rust-src llvm-tools-preview
   displayName: 'Install Rustup Components'
 
-- script: |
-    cargo install cargo-xbuild --debug
-    cargo install bootimage --debug
+- script: cargo install cargo-xbuild bootimage --debug
   displayName: 'Install cargo-xbuild and bootimage'
 
-- script: bootimage build
+- script: cargo bootimage
   displayName: 'Build'
 
 - script: rustup component add rustfmt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,8 +55,11 @@ steps:
 - script: cargo install cargo-xbuild bootimage --debug
   displayName: 'Install cargo-xbuild and bootimage'
 
-- script: cargo bootimage
+- script: cargo xbuild
   displayName: 'Build'
+
+- script: cargo bootimage
+  displayName: 'Create Bootimage'
 
 - script: rustup component add rustfmt
   displayName: 'Install Rustfmt'


### PR DESCRIPTION
This updates the `post-02` branch for the changes of #582:

- Adds a `.cargo/config` file that defines a default target and a target runner
- Updates the CI scripts
- Updates the Readme with new build and run instructions
- Updates the bootloader to version 0.6.0 ([changelog](https://github.com/rust-osdev/bootloader/blob/master/Changelog.md#060))
  - This is required for the updated Paging Implementation post


Blocked on #582.