### PR TITLE
`unsafe impl` for `FrameAllocator<Size4KiB>` trait

### DIFF
--- a/blog/content/second-edition/posts/09-paging-implementation/index.md
+++ b/blog/content/second-edition/posts/09-paging-implementation/index.md
@@ -775,7 +775,7 @@ Let's start with the simple case and assume that we don't need to create new pag
 /// A FrameAllocator that always returns `None`.
 pub struct EmptyFrameAllocator;
 
-impl FrameAllocator<Size4KiB> for EmptyFrameAllocator {
+unsafe impl FrameAllocator<Size4KiB> for EmptyFrameAllocator {
     fn allocate_frame(&mut self) -> Option<PhysFrame> {
         None
     }
@@ -926,7 +926,7 @@ Now we can implement the `FrameAllocator` trait:
 ```rust
 // in src/memory.rs
 
-impl FrameAllocator<Size4KiB> for BootInfoFrameAllocator {
+unsafe impl FrameAllocator<Size4KiB> for BootInfoFrameAllocator {
     fn allocate_frame(&mut self) -> Option<PhysFrame> {
         let frame = self.usable_frames().nth(self.next);
         self.next += 1;


### PR DESCRIPTION
Replace `impl` by `unsafe impl`