### PR TITLE
Remove unecessary `use` statement

### DIFF
--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -196,7 +196,6 @@ fn test_println_many() {
 
 #[test_case]
 fn test_println_output() {
-    use core::fmt::Write;
     use x86_64::instructions::interrupts;
 
     serial_print!("test_println_output... ");


### PR DESCRIPTION
The line `use core::fmt::Write;` is probably not necessary since `Write` is not present.