### PR TITLE
Always use spaces for code (if possible)

### DIFF
--- a/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
@@ -312,7 +312,7 @@ static HELLO: &[u8] = b"Hello World!";
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
-	let vga_buffer = 0xb8000 as *mut u8;
+    let vga_buffer = 0xb8000 as *mut u8;
 
     for (i, &byte) in HELLO.iter().enumerate() {
         unsafe {
@@ -321,7 +321,7 @@ pub extern "C" fn _start() -> ! {
         }
     }
 
-	loop {}
+    loop {}
 }
 ```
 

--- a/blog/static/css/main.css
+++ b/blog/static/css/main.css
@@ -13,7 +13,7 @@
 }
 
 .front-page-introduction {
-	margin-bottom: 2rem;
+  margin-bottom: 2rem;
 }
 
 .navigation {


### PR DESCRIPTION
Almost all the code in the blog uses spaces instead of tabs.
This change fixes 3 places where there was inconsistancy.

This was causing some of the content to appear misaligned.

Now tabs are only used in:
  - Makefiles
  - Dockerfiles
  - Command output (from `objdump` and `diff`) containing tabs
  - `.fish` files