### PR TITLE
Added false to write_str

### DIFF
--- a/tests/panic_handler.rs
+++ b/tests/panic_handler.rs
@@ -66,6 +66,8 @@ impl fmt::Write for CompareMessage {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         if s == MESSAGE {
             self.equals = true;
+        } else {
+            self.equals = false;
         }
         Ok(())
     }


### PR DESCRIPTION
WIthout the ability to set equals to false, the function doesn't correctly handle failing comparisions.