### PR TITLE
add  #![feature(exclusive_range_pattern)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
- #![feature(exclusive_range_pattern)]
+#![feature(exclusive_range_pattern)]
 
 use core::panic::PanicInfo;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
+ #![feature(exclusive_range_pattern)]
 
 use core::panic::PanicInfo;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(blog_os::test_runner)]
 #![reexport_test_harness_main = "test_main"]
+#![feature(exclusive_range_pattern)]
 
 use blog_os::println;
 use core::panic::PanicInfo;


### PR DESCRIPTION
Getting the following compilation error when directive is not specified:

error[E0658]: exclusive range pattern syntax is experimental
  --> src/vga_buffer.rs:74:17
   |
74 |                 0x20..0x7e | b'\n' => self.write_byte(byte),
   |                 ^^^^^^^^^^
   |
   = note: for more information, see https://github.com/rust-lang/rust/issues/37854
   = help: add #![feature(exclusive_range_pattern)] to the crate attributes to enable