### PR TITLE
Run `brew update` on macOS to fix travis CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ addons:
   homebrew:
     packages:
       - qemu
+    update: true
 
 install:
   - if [ $TRAVIS_OS_NAME = windows ]; then choco install qemu; export PATH="/c/Program Files/qemu:$PATH"; fi


### PR DESCRIPTION
According to https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos, travis does not run `brew update` by default. The problem is that without it, the installation of QEMU fails with:

```
Error: Your Homebrew is outdated. Please run `brew update`.
Error: Kernel.exit
```

This PR fixes the CI failure by running `brew update` before installation, even though it needs more time.