### PR TITLE
Add June status update post

### DIFF
--- a/blog/content/status-update/2019-06-04.md
+++ b/blog/content/status-update/2019-06-04.md
@@ -1,0 +1,32 @@
++++
+title = "Updates in June 2019"
+date = 2019-07-06
++++
+
+This post gives an overview of the recent updates to the _Writing an OS in Rust_ blog and the used libraries and tools.
+
+My focus this month was to finish the [_Heap Allocation_](./second-edition/posts/10-heap-allocation/index.md) post, on which I had been working since March. I originally wanted to include a section about different allocator designs (bump, linked list, slab, …) and how to implement them, but I decided to split it out into a separate post because it became much too long. I try to release this half-done post soon.
+
+Apart from the new post, there were some minor updates to the `x86_64`, `bootloader` and `cargo-xbuild` crates. The following gives a short overview of notable changes to the different projects.
+
+## blog_os
+
+- [Use misspell tool to look for common typos](https://github.com/phil-opp/blog_os/pull/617)
+- [New post about heap allocation](https://github.com/phil-opp/blog_os/pull/625)
+
+## x86_64
+
+- [Add ring-3 flag to GDT descriptor](https://github.com/rust-osdev/x86_64/pull/77) by [@mark-i-m](https://github.com/mark-i-m) (released as version 0.7.1)
+- [Add bochs magic breakpoint, read instruction pointer, inline instructions](https://github.com/rust-osdev/x86_64/pull/79) by [@64](https://github.com/64)
+
+## bootloader
+
+- [Make the physical memory offset configurable through a `BOOTLOADER_PHYSICAL_MEMORY_OFFSET` environment variable](https://github.com/rust-osdev/bootloader/pull/58)
+- [Use a stripped copy of the kernel binary (debug info removed) to reduce load times](https://github.com/rust-osdev/bootloader/pull/59) (released as version 0.6.1)
+
+<!-- ## Bootimage -->
+
+## cargo-xbuild
+
+- [Document the XBUILD_SYSROOT_PATH environment variable](https://github.com/rust-osdev/cargo-xbuild/commit/994b5e75e1a4062cf506700e0ff38d5404338a37)
+- [Fix incorrect joining of paths that caused some problems on Windows](https://github.com/rust-osdev/cargo-xbuild/commit/a1ff03311dd74447e8e845b4b96f2e137850027d)


### PR DESCRIPTION
This PR adds an "Updates in June 2019" post that gives a short overview of the recent changes to the blog and the tools/libraries behind the scenes.