### PR TITLE
fix "non-primitive cast: `x86_64::addr::VirtAddr` as `u64`"

### DIFF
--- a/tests/heap_allocation.rs
+++ b/tests/heap_allocation.rs
@@ -20,7 +20,7 @@ fn main(boot_info: &'static BootInfo) -> ! {
 
     blog_os::init();
     let phys_mem_offset = VirtAddr::new(boot_info.physical_memory_offset);
-    let mut mapper = unsafe { memory::init(phys_mem_offset) };
+    let mut mapper = unsafe { memory::init(phys_mem_offset.as_u64()) };
     let mut frame_allocator = unsafe { BootInfoFrameAllocator::init(&boot_info.memory_map) };
     allocator::init_heap(&mut mapper, &mut frame_allocator).expect("heap initialization failed");
 


### PR DESCRIPTION
```
error[E0605]: non-primitive cast: `x86_64::addr::VirtAddr` as `u64`
  --> tests\heap_allocation.rs:25:41
   |
25 |     let mut mapper = unsafe { memory::init(phys_mem_offset as u64) };
   |                                            ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: an `as` expression can only be used to convert between primitive types. Consider using the `From` trait
```