### PR TITLE
Fix non-primitive cast: `x86_64::addr::VirtAddr` as `u64`

### DIFF
--- a/blog/content/second-edition/posts/10-heap-allocation/index.md
+++ b/blog/content/second-edition/posts/10-heap-allocation/index.md
@@ -682,7 +682,7 @@ fn main(boot_info: &'static BootInfo) -> ! {
 
     blog_os::init();
     let phys_mem_offset = VirtAddr::new(boot_info.physical_memory_offset);
-    let mut mapper = unsafe { memory::init(phys_mem_offset) };
+    let mut mapper = unsafe { memory::init(phys_mem_offset.as_u64()) };
     let mut frame_allocator = unsafe {
         BootInfoFrameAllocator::init(&boot_info.memory_map)
     };


### PR DESCRIPTION
Initial condition:
`memory::init()` expects `u64` as argument
Problem:
The type of `phys_mem_offset` is `x86_64::VirtAddr`
Solution:
Call the member function `as_u64()` to cast `phys_mem_offset` as `u64`