### PR TITLE
Don't fail job if `zola check` fails

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -53,6 +53,7 @@ jobs:
     - name: "Run zola check"
       run: ../zola check
       working-directory: "blog"
+      continue-on-error: true
 
   check_spelling:
     name: "Check Spelling"


### PR DESCRIPTION
The external link checker of the `zola check` command has false positives, e.g. https://github.com/getzola/zola/issues/805.