### PR TITLE
Fix escaping issues by adding `safe` filters in more places

### DIFF
--- a/blog/templates/404.html
+++ b/blog/templates/404.html
@@ -6,7 +6,7 @@
     <h1>Page not found</h1>
     <p>Sorry, this address is not valid.</p>
 
-    <p><a href="{{ config.base_url }}">Go to the index page</a>.</p>
+    <p><a href="{{ config.base_url | safe }}">Go to the index page</a>.</p>
 
     <p>If you followed a link on this site, please <a href="https://github.com/phil-opp/blog_os/issues">report it</a>!</p>
 {% endblock main %}

--- a/blog/templates/first-edition/base.html
+++ b/blog/templates/first-edition/base.html
@@ -24,7 +24,7 @@
             <h1 class="masthead-title">
                 <a href="/first-edition" title="Home">{{ config.title }} (First Edition)</a>
             </h1>
-            <p><small>{{ config.extra.subtitle }}</small></p>
+            <p><small>{{ config.extra.subtitle | replace(from=" ", to="&nbsp;") | safe }}</small></p>
         </header>
 
         <main>{% block main %}{% endblock main %}</main>
@@ -35,7 +35,7 @@
             <hr>
             <small>
                 &copy; <time datetime="2017">2017</time>. All rights reserved.
-                <a href="{{ get_url(path="@/pages/contact.md") }}">Contact</a>
+                <a href="{{ get_url(path="@/pages/contact.md") | safe }}">Contact</a>
             </small>
         </footer>
     </div>

--- a/blog/templates/first-edition/handling-exceptions-with-naked-fns.html
+++ b/blog/templates/first-edition/handling-exceptions-with-naked-fns.html
@@ -6,6 +6,6 @@
 
 {% block introduction %}
 
-    <p>These posts explain how to handle CPU exceptions using naked functions. Historically, these posts were the main exception handling posts before the <code>x86-interrupt</code> calling convention and the <code>x86_64</code> crate existed. Our new way of handling exceptions can be found in the <a href="{{ get_url(path="@/first-edition/posts/09-handling-exceptions/index.md") }}">“Handling Exceptions”</a> post.</p>
+    <p>These posts explain how to handle CPU exceptions using naked functions. Historically, these posts were the main exception handling posts before the <code>x86-interrupt</code> calling convention and the <code>x86_64</code> crate existed. Our new way of handling exceptions can be found in the <a href="{{ get_url(path="@/first-edition/posts/09-handling-exceptions/index.md") | safe }}">“Handling Exceptions”</a> post.</p>
 
 {% endblock introduction %}

--- a/blog/templates/first-edition/index.html
+++ b/blog/templates/first-edition/index.html
@@ -21,7 +21,7 @@
 </div>
 
 <div class="warning">
-    <b>No longer updated!</b> You are viewing the first edition of “Writing an OS in Rust”, which is no longer updated. You can find the second edition <a href="{{ get_url(path = "@/second-edition/_index.md") }}">here</a>.
+    <b>No longer updated!</b> You are viewing the first edition of “Writing an OS in Rust”, which is no longer updated. You can find the second edition <a href="{{ get_url(path = "@/second-edition/_index.md") | safe }}">here</a>.
 </div>
 
 <div id="bare-bones" class="post-category bare-bones">Bare Bones</div>

--- a/blog/templates/first-edition/page.html
+++ b/blog/templates/first-edition/page.html
@@ -26,7 +26,7 @@
     </aside>
 
     <div class="warning">
-        <b>No longer updated!</b> You are viewing the a post of the first edition of “Writing an OS in Rust”, which is no longer updated. You can find the second edition <a href="{{ get_url(path = "@/second-edition/_index.md") }}">here</a>.
+        <b>No longer updated!</b> You are viewing the a post of the first edition of “Writing an OS in Rust”, which is no longer updated. You can find the second edition <a href="{{ get_url(path = "@/second-edition/_index.md") | safe }}">here</a>.
     </div>
 
     {{ page.content | safe }}

--- a/blog/templates/redirect-to-frontpage.html
+++ b/blog/templates/redirect-to-frontpage.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <link rel="canonical" href="{{ config.base_url }}" />
+        <link rel="canonical" href="{{ config.base_url | safe }}" />
         <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-        <meta http-equiv="refresh" content="0;url={{ config.base_url }}" />
+        <meta http-equiv="refresh" content="0;url={{ config.base_url | safe }}" />
     </head>
 </html>

--- a/blog/templates/second-edition/base.html
+++ b/blog/templates/second-edition/base.html
@@ -25,9 +25,9 @@
         <header class="masthead">
             <div style="position:relative">
                 <h1 class="masthead-title">
-                    <a href="{{ config.base_url }}" title="Home">{{ config.title }} (Second Edition)</a>
+                    <a href="{{ config.base_url | safe }}" title="Home">{{ config.title | safe }} (Second Edition)</a>
                 </h1>
-                <p><small>{{ config.extra.subtitle | replace(from=" ", to="&nbsp;")}}</small></p>
+                <p><small>{{ config.extra.subtitle | replace(from=" ", to="&nbsp;") | safe }}</small></p>
                 {% block header %}{% endblock header %}
             </div>
         </header>
@@ -40,7 +40,7 @@
             <hr>
             <small>
                 &copy; <time datetime="2019">2019</time>. All rights reserved.
-                <a href="{{ get_url(path="@/pages/contact.md") }}">Contact</a>
+                <a href="{{ get_url(path="@/pages/contact.md") | safe }}">Contact</a>
             </small>
         </footer>
     </div>

--- a/blog/templates/second-edition/index.html
+++ b/blog/templates/second-edition/index.html
@@ -56,7 +56,7 @@
 
 <div class="posts first-edition">
     <h2 class="post-title">First Edition</h2>
-    You are viewing the second edition of “Writing an OS in Rust”, which is still in progress. The <a href="{{ get_url(path = "/first-edition") }}">first edition</a> has more content, but is no longer updated. We try our best to incorporate the missing content soon.
+    You are viewing the second edition of “Writing an OS in Rust”, which is still in progress. The <a href="{{ get_url(path = "/first-edition") | safe }}">first edition</a> has more content, but is no longer updated. We try our best to incorporate the missing content soon.
 </div>
 
 <hr>
@@ -82,7 +82,7 @@
         {% for page in status_updates.pages | slice(end=3) %}
             <li><b><a href="/{{ page.path | safe }}">{{ page.title }}</a></b></li>
         {% endfor %}
-        <li><a href="{{ get_url(path="@/status-update/_index.md") }}"><em>view all »</em></a></li>
+        <li><a href="{{ get_url(path="@/status-update/_index.md") | safe }}"><em>view all »</em></a></li>
     </ul>
 </div>
 

--- a/blog/templates/second-edition/page.html
+++ b/blog/templates/second-edition/page.html
@@ -4,7 +4,7 @@
 
 {% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
 {% block header %}
-    <aside id="all-posts-link"><a href="{{ config.base_url }}" title="All Posts">« All Posts</a></aside>
+    <aside id="all-posts-link"><a href="{{ config.base_url | safe }}" title="All Posts">« All Posts</a></aside>
 {% endblock header %}
 
 {% block main %}
@@ -31,7 +31,7 @@
     {% if page.extra.warning %}
         <div class="warning">
             {% if page.extra.warning_short %} <b>{{ page.extra.warning_short }}</b> {% endif %}
-            {{ page.extra.warning | markdown(inline=true)}}
+            {{ page.extra.warning | markdown(inline=true) | safe }}
         </div>
     {% endif %}
 


### PR DESCRIPTION
Zola 0.9 changed the way the `safe` filter is automatically applied and thus lead to escaping issues. This pull request fixes this by adding the `safe` filter in more places in the templates.

Fixes the escaping issues reported in https://www.reddit.com/r/rust/comments/de5hvu/writing_an_os_in_rust_updates_in_september_2019/f2xzr3o/.