### PR TITLE
Use panic! instead of println! + loop in double fault handler

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -33,8 +33,7 @@ extern "x86-interrupt" fn double_fault_handler(
     stack_frame: &mut InterruptStackFrame,
     _error_code: u64,
 ) {
-    println!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
-    loop {}
+    panic!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This avoids an endless loop when a double fault occurs while running `cargo xtest`.

The blog post already uses the panic version, it is just the `post-06` branch that is out of sync.

Reported in https://github.com/phil-opp/blog_os/issues/449#issuecomment-551581648.