### PR TITLE
post-07: Use panic instead of println + hlt_loop for double fault handler

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -60,8 +60,7 @@ extern "x86-interrupt" fn double_fault_handler(
     stack_frame: &mut InterruptStackFrame,
     _error_code: u64,
 ) {
-    println!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
-    hlt_loop();
+    panic!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
 }
 
 extern "x86-interrupt" fn timer_interrupt_handler(_stack_frame: &mut InterruptStackFrame) {

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -4,7 +4,7 @@
 // problem we skip compilation of this module on Windows.
 #![cfg(not(windows))]
 
-use crate::{gdt, hlt_loop, print, println};
+use crate::{gdt, print, println};
 use lazy_static::lazy_static;
 use pic8259_simple::ChainedPics;
 use spin;


### PR DESCRIPTION
See https://github.com/phil-opp/blog_os/pull/687

Requires an update to the _Hardware Interrupts_ post (_Edit_: Done in https://github.com/phil-opp/blog_os/pull/690).