### PR TITLE
Hardware Interrupts: Don't replace panic in double fault handler

### DIFF
--- a/blog/content/second-edition/posts/07-hardware-interrupts/index.md
+++ b/blog/content/second-edition/posts/07-hardware-interrupts/index.md
@@ -502,22 +502,6 @@ pub fn test_panic_handler(info: &PanicInfo) -> ! {
 }
 ```
 
-We can also use `hlt_loop` in our double fault exception handler:
-
-```rust
-// in src/interrupts.rs
-
-use crate::hlt_loop; // new
-
-extern "x86-interrupt" fn double_fault_handler(
-    stack_frame: &mut InterruptStackFrame,
-    _error_code: u64,
-) {
-    println!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
-    hlt_loop(); // new
-}
-```
-
 When we run our kernel now in QEMU, we see a much lower CPU usage.
 
 ## Keyboard Input


### PR DESCRIPTION
See https://github.com/phil-opp/blog_os/pull/687 and https://github.com/phil-opp/blog_os/pull/689.