### PR TITLE
Show translated content directly on index page

### DIFF
--- a/blog/static/css/main.css
+++ b/blog/static/css/main.css
@@ -102,8 +102,9 @@ main img {
   margin-left: 5px;
 }
 
-.post-translation {
+.no-translation {
   margin-top: .3rem;
+  color: #999999;
 }
 
 .post-category {

--- a/blog/templates/macros.html
+++ b/blog/templates/macros.html
@@ -1,16 +1,21 @@
 {% macro post_link(page) %}
     <div>
-        <h2 class="post-title"><a href="/{{ page.path | safe }}">{{ page.title }}</a></h2>
+        {% set translations = page.translations | filter(attribute="lang", value=lang) %}
+        {% if translations %}
+            {% set post = get_page(path = translations.0.path) %}
+        {% else %}
+            {% set post = page %}
+            {% set not_translated = true %}
+        {% endif %}
+        <h2 class="post-title"><a href="/{{ post.path | safe }}">{{ post.title }}</a></h2>
         <div class="post-summary">
-            {{ page.summary | safe}}
-            <a class="read-more" href="/{{ page.path | safe }}">read&nbsp;more…</a>
+            {{ post.summary | safe}}
+            <a class="read-more" href="/{{ post.path | safe }}">read&nbsp;more…</a>
 
-            {% set translations = page.translations | filter(attribute="lang", value=lang) %}
-            {% if translations %}
-            <div class="post-translation">
-                {% set post = translations.0 %}
-                <b>Community Translation: <a href="{{ post.permalink }}">{{ post.title }}</a></b>
-            </div>
+            {% if not_translated %}
+            <aside class="no-translation">
+                (This post is not translated yet.)
+            </aside>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
instead of only providing a 'Community Translation' link.

~Blocked on https://github.com/getzola/zola/issues/859.~ The required functionality was merged in https://github.com/getzola/zola/pull/863.