### PR TITLE
Make double fault handlers diverging

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -26,7 +26,7 @@ extern "x86-interrupt" fn breakpoint_handler(stack_frame: &mut InterruptStackFra
 extern "x86-interrupt" fn double_fault_handler(
     stack_frame: &mut InterruptStackFrame,
     _error_code: u64,
-) {
+) -> ! {
     panic!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
 }
 

--- a/tests/stack_overflow.rs
+++ b/tests/stack_overflow.rs
@@ -45,7 +45,7 @@ pub fn init_test_idt() {
 extern "x86-interrupt" fn test_double_fault_handler(
     _stack_frame: &mut InterruptStackFrame,
     _error_code: u64,
-) {
+) -> ! {
     serial_println!("[ok]");
     exit_qemu(QemuExitCode::Success);
     loop {}


### PR DESCRIPTION
Required by x86_64 0.8.0.

Update to x86_64 0.8.0 ocurred in https://github.com/phil-opp/blog_os/pull/701.