### PR TITLE
Move #[global_allocator] into allocator module

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,5 +1,6 @@
 use alloc::alloc::{GlobalAlloc, Layout};
 use core::ptr::null_mut;
+use linked_list_allocator::LockedHeap;
 use x86_64::{
     structures::paging::{
         mapper::MapToError, FrameAllocator, Mapper, Page, PageTableFlags, Size4KiB,
@@ -9,6 +10,9 @@ use x86_64::{
 
 pub const HEAP_START: usize = 0x_4444_4444_0000;
 pub const HEAP_SIZE: usize = 100 * 1024; // 100 KiB
+
+#[global_allocator]
+static ALLOCATOR: LockedHeap = LockedHeap::empty();
 
 pub fn init_heap(
     mapper: &mut impl Mapper<Size4KiB>,
@@ -31,7 +35,7 @@ pub fn init_heap(
     }
 
     unsafe {
-        super::ALLOCATOR.lock().init(HEAP_START, HEAP_SIZE);
+        ALLOCATOR.lock().init(HEAP_START, HEAP_SIZE);
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 extern crate alloc;
 
 use core::panic::PanicInfo;
-use linked_list_allocator::LockedHeap;
 
 pub mod allocator;
 pub mod gdt;
@@ -17,9 +16,6 @@ pub mod interrupts;
 pub mod memory;
 pub mod serial;
 pub mod vga_buffer;
-
-#[global_allocator]
-static ALLOCATOR: LockedHeap = LockedHeap::empty();
 
 pub fn init() {
     gdt::init();


### PR DESCRIPTION
The Rust issue that the #[global_allocator] cannot be defined in submodules was fixed.