### PR TITLE
Update many_boxes test to scale with heap size

### DIFF
--- a/tests/heap_allocation.rs
+++ b/tests/heap_allocation.rs
@@ -7,7 +7,7 @@
 extern crate alloc;
 
 use alloc::{boxed::Box, vec::Vec};
-use blog_os::{serial_print, serial_println};
+use blog_os::{allocator::HEAP_SIZE, serial_print, serial_println};
 use bootloader::{entry_point, BootInfo};
 use core::panic::PanicInfo;
 
@@ -51,7 +51,7 @@ fn large_vec() {
 #[test_case]
 fn many_boxes() {
     serial_print!("many_boxes... ");
-    for i in 0..10_000 {
+    for i in 0..HEAP_SIZE {
         let x = Box::new(i);
         assert_eq!(*x, i);
     }


### PR DESCRIPTION
Instead of using a hardcoded number of boxes, use the HEAP_SIZE constant. This ensures that we get a test failure because of an out-of-memory error when the allocator does not reuse freed memory.