### PR TITLE
Fix dummy allocator code example

### DIFF
--- a/blog/content/second-edition/posts/10-heap-allocation/index.md
+++ b/blog/content/second-edition/posts/10-heap-allocation/index.md
@@ -309,7 +309,7 @@ The `#[global_allocator]` attribute tells the Rust compiler which allocator inst
 // in src/allocator.rs
 
 #[global_allocator]
-static ALLOCATOR: allocator::Dummy = allocator::Dummy;
+static ALLOCATOR: Dummy = Dummy;
 ```
 
 Since the `Dummy` allocator is a [zero sized type], we don't need to specify any fields in the initialization expression.


### PR DESCRIPTION
We forgot to remove the `allocator::` prefix when moving the ALLOCATOR declaration into the `allocator` module in #714.

Reported in https://github.com/phil-opp/blog_os/issues/627#issuecomment-579286343.