### PR TITLE
Updates in January 2020

### DIFF
--- a/blog/content/status-update/2020-02-01.md
+++ b/blog/content/status-update/2020-02-01.md
@@ -1,0 +1,69 @@
++++
+title = "Updates in January 2020"
+date = 2020-02-01
++++
+
+This post gives an overview of the recent updates to the _Writing an OS in Rust_ blog and the corresponding libraries and tools.
+
+## `blog_os`
+
+The repository of the _Writing an OS in Rust_ blog received the following updates:
+
+- [Move #[global_allocator] into allocator module](https://github.com/phil-opp/blog_os/pull/714)
+- [Update many_boxes test to scale with heap size](https://github.com/phil-opp/blog_os/pull/716)
+- [New post about allocator designs](https://github.com/phil-opp/blog_os/pull/719) 🎉
+- [Provide multiple implementations of align_up and mention performance](https://github.com/phil-opp/blog_os/pull/721)
+- [Refactor Simplified Chinese translation of post 3](https://github.com/phil-opp/blog_os/pull/725) by [@Rustin-Liu](https://github.com/Rustin-Liu)
+- [Use checked addition for allocator implementations](https://github.com/phil-opp/blog_os/pull/726)
+- [Fix dummy allocator code example](https://github.com/phil-opp/blog_os/pull/728)
+- [Some style updates to the front page](https://github.com/phil-opp/blog_os/pull/729)
+- [Mark active item in table of contents](https://github.com/phil-opp/blog_os/pull/733)
+- [Make active section link more discreet](https://github.com/phil-opp/blog_os/pull/734) by [@Menschenkindlein](https://github.com/Menschenkindlein)
+
+I also started working on the upcoming post about threads.
+
+## `bootloader`
+
+The bootloader crate received two minor updates this month:
+
+- [Move architecture checks from build script into lib.rs](https://github.com/rust-osdev/bootloader/pull/91)
+- [Update x86_64 dependency to version 0.8.3](https://github.com/rust-osdev/bootloader/pull/92) by [@vinaychandra](https://github.com/vinaychandra)
+
+Since I focused my time on the new _Allocator Designs_ post, I did not have the time to make more progress on my plan to rewrite the 16-bit/32-bit stages of the bootloader in Rust. I hope to get back to it soon.
+
+## `bootimage`
+
+There were no updates to the `bootimage` tool this month.
+
+## `x86_64`
+
+The following changes were merged this month:
+
+- [Allow immediate port version of in/out instructions](https://github.com/rust-osdev/x86_64/pull/115) by [@m-ou-se](https://github.com/m-ou-se)
+- [Make more functions const](https://github.com/rust-osdev/x86_64/pull/116) by [@m-ou-se](https://github.com/m-ou-se)
+    - Released as version 0.8.3
+- [Return the UnusedPhysFrame on MapToError::PageAlreadyMapped](https://github.com/rust-osdev/x86_64/pull/118) by [@haraldh](https://github.com/haraldh)
+    - This is a **breaking change** since it changes the signature of a type.
+    - No new release was published yet to give us the option to bundle it with other breaking changes.
+
+There are also some pull requests that have some open design questions and are still being discussed:
+
+- [Add p23_insert_flag_mask argument to mapper.map_to()](https://github.com/rust-osdev/x86_64/pull/114) by [@haraldh](https://github.com/haraldh)
+    - Related proposal: [Page Table Visitors](https://github.com/rust-osdev/x86_64/issues/121) by [@mark-i-m](https://github.com/mark-i-m)
+- [Add User Mode registers](https://github.com/rust-osdev/x86_64/pull/119) by [@vinaychandra](https://github.com/vinaychandra)
+
+Please feel free to join these discussions if you have opinions on the matter.
+
+## `cargo-xbuild`
+
+The `cargo-xbuild` crate, which cross-compiles the sysroot, received the following updates this month:
+
+- [Override target path for building sysroot](https://github.com/rust-osdev/cargo-xbuild/pull/52) by [@upsuper](https://github.com/upsuper)
+    - Published as version 0.5.21
+
+## `uart_16550`
+
+The `uart_16550` crate, which provides basic support for uart_16550 serial output, received a small dependency update:
+
+- [Update dependency for x86_64](https://github.com/rust-osdev/uart_16550/pull/4) by [@haraldh](https://github.com/haraldh)
+    - Published as version 0.2.2

--- a/blog/templates/status-update-page.html
+++ b/blog/templates/status-update-page.html
@@ -14,7 +14,8 @@
 
     <div>
         <h2>Thank You!</h2>
-        <p>I want to thank all the people who support me on <a href="https://github.com/sponsors/phil-opp">GitHub</a>, <a href="https://www.patreon.com/phil_opp">Patreon</a>, and <a href="https://donorbox.org/phil-opp">Donorbox</a>. It means a lot to me!</p>
+        <p>Thanks to all the contributors this month!</p>
+        <p>I also want to thank all the people who support me on <a href="https://github.com/sponsors/phil-opp">GitHub</a>, <a href="https://www.patreon.com/phil_opp">Patreon</a>, and <a href="https://donorbox.org/phil-opp">Donorbox</a>. It means a lot to me!</p>
     </div>
 {% endblock main %}
 


### PR DESCRIPTION
This PR adds an "Updates in January 2020" post that gives a short overview of the recent changes to the blog and the tools/libraries behind the scenes.