### PR TITLE
Don't panic on overflow in allocator; return null pointer instead

### DIFF
--- a/src/allocator/bump.rs
+++ b/src/allocator/bump.rs
@@ -36,7 +36,10 @@ unsafe impl GlobalAlloc for Locked<BumpAllocator> {
         let mut bump = self.lock(); // get a mutable reference
 
         let alloc_start = align_up(bump.next, layout.align());
-        let alloc_end = alloc_start.checked_add(layout.size()).expect("overflow");
+        let alloc_end = match alloc_start.checked_add(layout.size()) {
+            Some(end) => end,
+            None => return ptr::null_mut(),
+        };
 
         if alloc_end > bump.heap_end {
             ptr::null_mut() // out of memory

--- a/src/allocator/linked_list.rs
+++ b/src/allocator/linked_list.rs
@@ -86,7 +86,7 @@ impl LinkedListAllocator {
     /// Returns the allocation start address on success.
     fn alloc_from_region(region: &ListNode, size: usize, align: usize) -> Result<usize, ()> {
         let alloc_start = align_up(region.start_addr(), align);
-        let alloc_end = alloc_start.checked_add(size).expect("overflow");
+        let alloc_end = alloc_start.checked_add(size).ok_or(())?;
 
         if alloc_end > region.end_addr() {
             // region too small


### PR DESCRIPTION
Suggested in https://news.ycombinator.com/item?id=22230966