### PR TITLE
Add metadata to translations and list translators

### DIFF
--- a/blog/content/second-edition/posts/01-freestanding-rust-binary/index.zh-CN.md
+++ b/blog/content/second-edition/posts/01-freestanding-rust-binary/index.zh-CN.md
@@ -4,6 +4,11 @@ weight = 1
 path = "zh-CN/freestanding-rust-binary"
 date = 2018-02-10
 
+[extra]
+# Please update this when updating the translation
+translation_based_on_commit = "bd6fbcb1c36705b2c474d7fcee387bfea1210851"
+# GitHub usernames of the people that translated this post
+translators = ["luojia65", "Rustin-Liu", "TheBegining"]
 +++
 
 创建一个不链接标准库的 Rust 可执行文件，将是我们迈出的第一步。无需底层操作系统的支撑，这样才能在**裸机**（[bare metal]）上运行 Rust 代码。

--- a/blog/content/second-edition/posts/01-freestanding-rust-binary/index.zh-TW.md
+++ b/blog/content/second-edition/posts/01-freestanding-rust-binary/index.zh-TW.md
@@ -5,6 +5,7 @@ path = "zh-TW/freestanding-rust-binary"
 date = 2018-02-10
 
 [extra]
+# Please update this when updating the translation
 translation_based_on_commit = "24d04e0e39a3395ecdce795bab0963cb6afe1bfd"
 # GitHub usernames of the people that translated this post
 translators = ["wusyong"]

--- a/blog/content/second-edition/posts/02-minimal-rust-kernel/index.zh-CN.md
+++ b/blog/content/second-edition/posts/02-minimal-rust-kernel/index.zh-CN.md
@@ -4,6 +4,11 @@ weight = 2
 path = "zh-CN/minimal-rust-kernel"
 date = 2018-02-10
 
+[extra]
+# Please update this when updating the translation
+translation_based_on_commit = "bd6fbcb1c36705b2c474d7fcee387bfea1210851"
+# GitHub usernames of the people that translated this post
+translators = ["luojia65", "Rustin-Liu"]
 +++
 
 在这篇文章中，我们将基于 **x86架构**（the x86 architecture），使用 Rust 语言，编写一个最小化的 64 位内核。我们将从上一章中构建的独立式可执行程序开始，构建自己的内核；它将向显示器打印字符串，并能被打包为一个能够引导启动的**磁盘映像**（disk image）。

--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.zh-CN.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.zh-CN.md
@@ -4,6 +4,11 @@ weight = 3
 path = "zh-CN/vga-text-mode"
 date  = 2018-02-26
 
+[extra]
+# Please update this when updating the translation
+translation_based_on_commit = "bd6fbcb1c36705b2c474d7fcee387bfea1210851"
+# GitHub usernames of the people that translated this post
+translators = ["luojia65", "Rustin-Liu"]
 +++
 
 **VGA 字符模式**（[VGA text mode]）是打印字符到屏幕的一种简单方式。在这篇文章中，为了包装这个模式为一个安全而简单的接口，我们将包装 unsafe 代码到独立的模块。我们还将实现对 Rust 语言**格式化宏**（[formatting macros]）的支持。

--- a/blog/content/second-edition/posts/04-testing/index.zh-CN.md
+++ b/blog/content/second-edition/posts/04-testing/index.zh-CN.md
@@ -4,6 +4,11 @@ weight = 4
 path = "zh-CN/testing"
 date = 2019-04-27
 
+[extra]
+# Please update this when updating the translation
+translation_based_on_commit = "bd6fbcb1c36705b2c474d7fcee387bfea1210851"
+# GitHub usernames of the people that translated this post
+translators = ["luojia65", "Rustin-Liu"]
 +++
 
 本文主要讲述了在`no_std`环境下进行单元测试和集成测试的方法。我们将通过Rust的自定义测试框架来在我们的内核中执行一些测试函数。为了将结果反馈到QEMU上，我们需要使用QEMU的一些其他的功能以及`bootimage`工具。

--- a/blog/static/css/main.css
+++ b/blog/static/css/main.css
@@ -328,6 +328,10 @@ div.warning {
   background-color: #ffa50022;
 }
 
+div.warning p:last-child {
+  margin-bottom: 0;
+}
+
 form.subscribe {
   margin: 1rem;
 }

--- a/blog/templates/second-edition/page.html
+++ b/blog/templates/second-edition/page.html
@@ -47,8 +47,20 @@
         <div class="warning">
             {% set translations = page.translations | filter(attribute="lang", value="en") %}
             {% set original = translations.0 %}
+            <p>
             <b>Translated Content:</b>
-            This is a community translation of the <strong><a href="{{ original.permalink }}">{{ original.title }}</a></strong> post. It might be incomplete, outdated or contain errors. Please report any issues!
+                This is a community translation of the <strong><a href="{{ original.permalink }}">{{ original.title }}</a></strong> post. It might be incomplete, outdated or contain errors. Please report any issues!
+            </p>
+            {%- if page.extra.translators %}
+            <p>
+                Translation by {% for user in page.extra.translators -%}
+                    {%- if not loop.first -%}
+                        {%- if loop.last %}, and {% else %}, {% endif -%}
+                    {%- endif -%}
+                    <a href="https://github.com/{{user}}">@{{user}}</a>
+                {%- endfor %}.
+            </p>
+            {% endif -%}
         </div>
     {% endif %}
 


### PR DESCRIPTION
List the usernames of translators on translated posts to properly attribute the translation.

cc @luojia65 @Rustin-Liu @TheBegining @wusyong: This lists your usernames on posts that you translated. Let me know if you have a problem with this.