### PR TITLE
Align the double fault stack through a new wrapper type

### DIFF
--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -10,7 +10,11 @@ lazy_static! {
         let mut tss = TaskStateSegment::new();
         tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
             const STACK_SIZE: usize = 4096;
-            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+
+            #[repr(align(16))]
+            struct Stack([u8; STACK_SIZE]);
+
+            static mut STACK: Stack = Stack([0; STACK_SIZE]);
 
             let stack_start = VirtAddr::from_ptr(unsafe { &STACK });
             let stack_end = stack_start + STACK_SIZE;


### PR DESCRIPTION
See https://github.com/phil-opp/blog_os/issues/449#issuecomment-555811809

Requires an update of the _Double Faults_ post.