### PR TITLE
Updated pc-keyboard to `0.5.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "pc-keyboard"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff50ab09ba31bcebc0669f4e64c0952fae1acdca9e6e0587e68e4e8443808ac"
+checksum = "c48392db76c4e9a69e0b3be356c5f97ebb7b14413c5e4fd0af4755dbf86e2fce"
 
 [[package]]
 name = "pic8259_simple"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ spin = "0.5.2"
 x86_64 = "0.8.1"
 uart_16550 = "0.2.0"
 pic8259_simple = "0.1.1"
-pc-keyboard = "0.3.1"
+pc-keyboard = "0.5.0"
 
 [dependencies.lazy_static]
 version = "1.0"

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -66,13 +66,13 @@ extern "x86-interrupt" fn timer_interrupt_handler(_stack_frame: &mut InterruptSt
 }
 
 extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: &mut InterruptStackFrame) {
-    use pc_keyboard::{layouts, DecodedKey, Keyboard, ScancodeSet1};
+    use pc_keyboard::{layouts, DecodedKey, HandleControl, Keyboard, ScancodeSet1};
     use spin::Mutex;
     use x86_64::instructions::port::Port;
 
     lazy_static! {
         static ref KEYBOARD: Mutex<Keyboard<layouts::Us104Key, ScancodeSet1>> =
-            Mutex::new(Keyboard::new(layouts::Us104Key, ScancodeSet1));
+            Mutex::new(Keyboard::new(layouts::Us104Key, ScancodeSet1, HandleControl::MapLettersToUnicode));
     }
 
     let mut keyboard = KEYBOARD.lock();

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -71,12 +71,9 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: &mut Interrup
     use x86_64::instructions::port::Port;
 
     lazy_static! {
-        static ref KEYBOARD: Mutex<Keyboard<layouts::Us104Key, ScancodeSet1>> =
-            Mutex::new(Keyboard::new(
-                layouts::Us104Key,
-                ScancodeSet1,
-                HandleControl::MapLettersToUnicode
-            ));
+        static ref KEYBOARD: Mutex<Keyboard<layouts::Us104Key, ScancodeSet1>> = Mutex::new(
+            Keyboard::new(layouts::Us104Key, ScancodeSet1, HandleControl::Ignore)
+        );
     }
 
     let mut keyboard = KEYBOARD.lock();

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -72,7 +72,11 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: &mut Interrup
 
     lazy_static! {
         static ref KEYBOARD: Mutex<Keyboard<layouts::Us104Key, ScancodeSet1>> =
-            Mutex::new(Keyboard::new(layouts::Us104Key, ScancodeSet1, HandleControl::MapLettersToUnicode));
+            Mutex::new(Keyboard::new(
+                layouts::Us104Key,
+                ScancodeSet1,
+                HandleControl::MapLettersToUnicode
+            ));
     }
 
     let mut keyboard = KEYBOARD.lock();


### PR DESCRIPTION
I recently updated this in my project so I figured I'd help out since you do such great work. This should fix #742. The `keyboard::new` now takes 3 arguments, with the third being `pc_keyboard::HandleControl`. The two options are:
```
MapLettersToUnicode
If either Ctrl key is held down, convert the letters A through Z into Unicode chars U+0001 through U+001A. If the Ctrl keys are not held down, letters go through normally.

Ignore
Don't do anything special - send through the Ctrl key up/down events, and leave the letters as letters.
```
I left it `MapLettersToUnicode` for now since there's a match to handle Unicode characters, but it can be changed to `Ignore` if you prefer, just let me know.