### PR TITLE
Fixed minor typo in example code

### DIFF
--- a/blog/content/second-edition/posts/12-async-await/index.md
+++ b/blog/content/second-edition/posts/12-async-await/index.md
@@ -382,7 +382,7 @@ impl Future for ExampleStateMachine {
             match self { // TODO: handle pinning
                 ExampleStateMachine::Start(state) => {…}
                 ExampleStateMachine::WaitingOnFooTxt(state) => {…}
-                ExampleStateMachine::WaitingOnFooTxt(state) => {…}
+                ExampleStateMachine::WaitingOnBarTxt(state) => {…}
                 ExampleStateMachine::End(state) => {…}
             }
         }


### PR DESCRIPTION
`WaitingOnFooTxt` -> `WaitingOnBarTxt`