### PR TITLE
We no longer make entry points for Windows and macOS in post-01

### DIFF
--- a/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
@@ -235,7 +235,7 @@ pub extern "C" fn _start() -> ! {
 }
 ```
 
-Note that the entry point needs to be called `_start` regardless of your host OS. The Windows and macOS entry points from the previous post should be deleted.
+Note that the entry point needs to be called `_start` regardless of your host OS.
 
 We can now build the kernel for our new target by passing the name of the JSON file as `--target`:
 


### PR DESCRIPTION
This line confused me. I thought I'd read past something but it looks like the content in post-01 that it is referring to changed in 0b9ca847356c3f932e038d3b32d5e85a6e53e971.

Thanks for the blog!