### PR TITLE
Remove #![feature(alloc_layout_extra)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(abi_x86_interrupt)]
 #![feature(alloc_error_handler)]
 #![feature(const_fn)]
-#![feature(alloc_layout_extra)]
 #![feature(const_in_array_repeat_expressions)]
 #![feature(wake_trait)]
 #![test_runner(crate::test_runner)]


### PR DESCRIPTION
A subset of this feature was stabilized in https://github.com/rust-lang/rust/pull/69362,
and none of the still-unstable methods are in use in `blog_os`