### PR TITLE
Do a volatile read in stack_overflow test to avoid tail recursion 

### DIFF
--- a/tests/stack_overflow.rs
+++ b/tests/stack_overflow.rs
@@ -23,6 +23,7 @@ pub extern "C" fn _start() -> ! {
 #[allow(unconditional_recursion)]
 fn stack_overflow() {
     stack_overflow(); // for each recursion, the return address is pushed
+    volatile::Volatile::new(0).read(); // prevent tail recursion optimizations
 }
 
 lazy_static! {


### PR DESCRIPTION
This prevents the compiler from transforming the tail recursive function into a loop, which does not lead to a stack overflow. It also avoids the LLVM bug where functions with side-effect-free endless loops are removed. Thus, the test now also works in `--release` mode.

Suggested by @bjorn3 in https://github.com/phil-opp/blog_os/issues/449#issuecomment-640189459.