### PR TITLE
Fix grammar for freestanding-rust-binary linker arguments.

### DIFF
--- a/blog/content/second-edition/posts/01-freestanding-rust-binary/index.md
+++ b/blog/content/second-edition/posts/01-freestanding-rust-binary/index.md
@@ -403,7 +403,7 @@ macOS [does not officially support statically linked binaries] and requires prog
 cargo rustc -- -C link-args="-e __start -static"
 ```
 
-This still not suffices, as a third linker error occurs:
+This still does not suffice, as a third linker error occurs:
 
 ```
 error: linking with `cc` failed: exit code: 1


### PR DESCRIPTION
The grammar for MacOS linker arguments was clunky. Fix it to be grammatically correct.