### PR TITLE
Migrate post-02 code from cargo-xbuild to `-Zbuild-std`

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,5 @@
+unstable.build-std = ["core", "compiler_builtins"]
+
 [build]
 target = "x86_64-blog_os.json"
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,5 @@
-unstable.build-std = ["core", "compiler_builtins"]
+[unstable]
+build-std = ["core", "compiler_builtins"]
 
 [build]
 target = "x86_64-blog_os.json"

--- a/.github/workflows/build-code.yml
+++ b/.github/workflows/build-code.yml
@@ -49,11 +49,11 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
-      - name: "Install Rustup Components"
-        run: rustup component add rust-src llvm-tools-preview
       - name: "Install bootimage"
         run: cargo install bootimage --debug --git https://github.com/rust-osdev/bootimage.git --branch Zbuild-std
       - uses: actions/checkout@v2
+      - name: "Install Rustup Components"
+        run: rustup component add rust-src llvm-tools-preview
       - uses: actions-rs/cargo@v1
         with:
           command: bootimage

--- a/.github/workflows/build-code.yml
+++ b/.github/workflows/build-code.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
+      - name: "Install `rust-src` Rustup Component"
+        run: rustup component add rust-src
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/build-code.yml
+++ b/.github/workflows/build-code.yml
@@ -54,7 +54,7 @@ jobs:
           profile: minimal
           toolchain: nightly
       - name: Install bootimage
-        run: cargo install bootimage --debug --git https://github.com/rust-osdev/bootimage.git --branch Zbuild-std
+        run: cargo install bootimage --debug
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Install Rustup Components

--- a/.github/workflows/build-code.yml
+++ b/.github/workflows/build-code.yml
@@ -52,7 +52,7 @@ jobs:
       - name: "Install Rustup Components"
         run: rustup component add rust-src llvm-tools-preview
       - name: "Install bootimage"
-        run: cargo install bootimage --debug
+        run: cargo install bootimage --debug --git https://github.com/rust-osdev/bootimage.git --branch Zbuild-std
       - uses: actions/checkout@v2
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/build-code.yml
+++ b/.github/workflows/build-code.yml
@@ -38,7 +38,7 @@ jobs:
           command: check
 
   test:
-    name: Test Suite
+    name: Test
     strategy:
       matrix:
         platform: [
@@ -65,7 +65,7 @@ jobs:
           command: bootimage
 
   check_formatting:
-    name: Rustfmt
+    name: Check Formatting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-code.yml
+++ b/.github/workflows/build-code.yml
@@ -23,14 +23,17 @@ jobs:
         ]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
-      - name: "Install `rust-src` Rustup Component"
+      - name: Install `rust-src` Rustup Component
         run: rustup component add rust-src
-      - uses: actions-rs/cargo@v1
+      - name: Run `cargo check`
+        uses: actions-rs/cargo@v1
         with:
           command: check
 
@@ -45,16 +48,19 @@ jobs:
         ]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
-      - name: "Install bootimage"
+      - name: Install bootimage
         run: cargo install bootimage --debug --git https://github.com/rust-osdev/bootimage.git --branch Zbuild-std
-      - uses: actions/checkout@v2
-      - name: "Install Rustup Components"
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Install Rustup Components
         run: rustup component add rust-src llvm-tools-preview
-      - uses: actions-rs/cargo@v1
+      - name: Run `cargo bootimage`
+        uses: actions-rs/cargo@v1
         with:
           command: bootimage
 
@@ -62,14 +68,17 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           components: rustfmt
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: Run `cargo fmt`
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
@@ -78,14 +87,17 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           components: clippy, rust-src
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: Run `cargo clippy`
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/build-code.yml
+++ b/.github/workflows/build-code.yml
@@ -12,9 +12,8 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: "Test"
-
+  check:
+    name: Check
     strategy:
       matrix:
         platform: [
@@ -22,49 +21,67 @@ jobs:
           macos-latest,
           windows-latest
         ]
-
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 15
-
     steps:
-    - name: "Checkout Repository"
-      uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
 
-    - name: Install Rustup
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
-        echo ::add-path::$HOME/.cargo/bin
-      if: runner.os == 'macOS'
-
-    - name: "Print Rust Version"
-      run: |
-        rustc -Vv
-        cargo -Vv
-
-    - name: "Install Rustup Components"
-      run: rustup component add rust-src llvm-tools-preview
-    - name: "Install cargo-xbuild"
-      run: cargo install cargo-xbuild --debug
-    - name: "Install bootimage"
-      run: cargo install bootimage --debug
-
-    - name: "Run cargo xbuild"
-      run: cargo xbuild
-    - name: "Create Bootimage"
-      run: cargo bootimage
-
+  test:
+    name: Test Suite
+    strategy:
+      matrix:
+        platform: [
+          ubuntu-latest,
+          macos-latest,
+          windows-latest
+        ]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+      - name: "Install Rustup Components"
+        run: rustup component add rust-src llvm-tools-preview
+      - name: "Install bootimage"
+        run: cargo install bootimage --debug
+      - uses: actions/checkout@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: bootimage
 
   check_formatting:
-    name: "Check Formatting"
+    name: Rustfmt
     runs-on: ubuntu-latest
-    timeout-minutes: 2
     steps:
-    - uses: actions/checkout@v1
-    - name: "Use the latest Rust nightly with rustfmt"
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: nightly
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
           profile: minimal
-          components: rustfmt
-          override: true
-    - run: cargo fmt -- --check
+          toolchain: nightly
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/build-code.yml
+++ b/.github/workflows/build-code.yml
@@ -67,7 +67,8 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
-      - run: rustup component add rustfmt
+          components: rustfmt
+          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -82,7 +83,8 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
-      - run: rustup component add clippy
+          components: clippy, rust-src
+          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ name = "blog_os"
 version = "0.1.0"
 dependencies = [
  "bootloader",
+ "rlibc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,14 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.9.3"
+version = "0.9.5"
+source = "git+https://github.com/rust-osdev/bootloader.git?branch=Zbuild-std#874fe6ec5a0043b515ef74591b925bb527fb3c9a"
+dependencies = [
+ "rlibc",
+]
+
+[[package]]
+name = "rlibc"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ac0bdf4930c3c4d7f0d04eb6f15d7dcb9d5972b1ff9cd2bee0128112260fc7"
+checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,11 +10,9 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.9.5"
-source = "git+https://github.com/rust-osdev/bootloader.git?branch=Zbuild-std#874fe6ec5a0043b515ef74591b925bb527fb3c9a"
-dependencies = [
- "rlibc",
-]
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad686b9b47363de7d36c05fb6885f17d08d0f2d15b1bc782a101fe3c94a2c7c"
 
 [[package]]
 name = "rlibc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 bootloader = { git = "https://github.com/rust-osdev/bootloader.git", branch = "Zbuild-std" }
+rlibc = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = "0.9.3"
+bootloader = { git = "https://github.com/rust-osdev/bootloader.git", branch = "Zbuild-std" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = { git = "https://github.com/rust-osdev/bootloader.git", branch = "Zbuild-std" }
+bootloader = "0.9.8"
 rlibc = "1.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+extern crate rlibc;
+
 use core::panic::PanicInfo;
 
 static HELLO: &[u8] = b"Hello World!";


### PR DESCRIPTION
This pull request implements building using cargo's new [`build-std`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std) instead of using the [`cargo-xbuild`](https://github.com/rust-osdev/cargo-xbuild) crate.

To enable the `build-std` functionality, we set the `unstable.build-std` configuration key in the `.cargo/config.toml` file. This flag was introduced very recently in https://github.com/rust-lang/cargo/pull/8393, so it only works on the latest nightlies. Unfortunately, rustfmt doesn't build on these nightlies yet, so you have to use `rustup update nightly --force` to install them (results in skipping the rustfmt component).

Functionality-wise, the `build-std` feature behaves almost identical to `cargo-xbuild`. The only difference is that it doesn't enable the `mem` feature of the `compiler_builtins` crate, which defines the `memcpy`, `memset`, etc operations. This is a [known issue](https://github.com/rust-lang/wg-cargo-std-aware/issues/53), which is hopefully fixed soon. Until then, we can work around it by adding a dependency on the [`rlibc`](https://docs.rs/rlibc/1.0.0/rlibc/) crate. To ensure that this crate is linked even though it is not directly used, we need to add an `extern crate rlibc` statement to our `main.rs`.

After these changes, our kernel is buildable through a normal `cargo build`. The `cargo run` and `cargo test` commands will also work as expected, provided the latest bootimage version is used.

This PR additionally rewrites our CI script based on the GitHub Actions provided by the [`actions-rs`](https://github.com/actions-rs/) organization. This makes Rust's error messages compatible with GitHubs annotations, so that any build errors and warnings are shown inline at the correct line.

The required changes to the blog post will be done in a separate follow-up PR.