### PR TITLE
Use workflow dispatch event to trigger scheduled builds of code branches

### DIFF
--- a/.github/workflows/scheduled-builds.yml
+++ b/.github/workflows/scheduled-builds.yml
@@ -1,0 +1,33 @@
+name: Build code on schedule
+
+on:
+  schedule:
+    - cron: '40 1 * * *'   # every day at 1:40
+
+jobs:
+  trigger-build:
+    name: Trigger Build
+    strategy:
+      matrix:
+        branch: [
+          post-01,
+          post-02,
+          post-03,
+          post-04,
+          post-05,
+          post-06,
+          post-07,
+          post-08,
+          post-09,
+          post-10,
+          post-11,
+          post-12,
+        ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke workflow
+        uses: benc-uk/workflow-dispatch@v1.1
+        with:
+          workflow: Build Code
+          token: ${{ secrets.SCHEDULED_BUILDS_TOKEN }}
+          ref: ${{ matrix.branch }}


### PR DESCRIPTION
This enables nightly builds of the `post-XX` branches again. This way, we are directly notified if our code is broken by new Rust nightly versions.

We used to have these scheduled builds implemented when we used Travis CI and Azure Pipelines for our CI, but Github Actions did not support that initially (see https://github.community/t/scheduled-builds-of-non-default-branch/16306 and https://github.community/t/how-to-trigger-repository-dispatch-event-for-non-default-branch/14470). With the new `workflow_dispatch` event, we can now 