### PR TITLE
Update Zola to 0.11.0

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: 'Download Zola'
-      run: curl -sL https://github.com/getzola/zola/releases/download/v0.10.0/zola-v0.10.0-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+      run: curl -sL https://github.com/getzola/zola/releases/download/v0.11.0/zola-v0.11.0-x86_64-unknown-linux-gnu.tar.gz | tar zxv
     - name: "Install Python Tools"
       run: python -m pip install --upgrade pip setuptools wheel
     - name: 'Install Python Libraries'
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: 'Download Zola'
-      run: curl -sL https://github.com/getzola/zola/releases/download/v0.10.0/zola-v0.10.0-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+      run: curl -sL https://github.com/getzola/zola/releases/download/v0.11.0/zola-v0.11.0-x86_64-unknown-linux-gnu.tar.gz | tar zxv
 
     - name: "Run zola check"
       run: ../zola check

--- a/blog/config.toml
+++ b/blog/config.toml
@@ -4,7 +4,8 @@ description = "This blog series creates a small operating system in the Rust pro
 
 highlight_code = true
 highlight_theme = "visual-studio-dark"
-generate_rss = true
+generate_feed = true
+feed_filename = "rss.xml"
 
 languages = [
     { code = "zh-CN" }, # Chinese (simplified)

--- a/blog/config.toml
+++ b/blog/config.toml
@@ -26,8 +26,6 @@ skip_prefixes = [
 skip_anchor_prefixes = [
      "https://github.com/", # see https://github.com/getzola/zola/issues/805
      "https://docs.rs/x86_64/0.1.2/src/", # source code highlight
-     "https://www.math.utah.edu/docs/info/ld_3.html", # see https://github.com/getzola/zola/issues/948
-     "https://web.stanford.edu/class/cs140/projects/pintos/specs/freevga/vga/vgamem.htm", # see https://github.com/getzola/zola/issues/948
 ]
 
 [extra]

--- a/blog/templates/rss.xml
+++ b/blog/templates/rss.xml
@@ -6,7 +6,7 @@
         <generator>Zola</generator>
         <language>{{ config.default_language }}</language>
         <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
-        <lastBuildDate>{{ last_build_date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
+        <lastBuildDate>{{ last_updated | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
         {% for page in pages %}
             <item>
                 <title>{{ page.title }}</title>


### PR DESCRIPTION
This updates the blog to version 0.11.0 of Zola, which is the static site generator we use.

Most changes in Zola 0.11.0 are RSS feed related. This PR renames a few configuration keys to their new name and uses the `feed_filename` config key to keep our RSS file at `/rss.xml` to avoid breakage. Since the new version fixed anchor checking for uppercase HTML tags, we can remove some `zola check` exceptions.