### PR TITLE
Update `x86_64` to v0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "uart_16550"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58fc40dc1712664fc9b0a7bd8ca2f21ab49960924fb245a80a05e1e92f3dfe9"
+checksum = "74cba8625e8a1ec064fc6440aef7921ff21b06f1ed60dd603cb1b1d5e0dfcd46"
 dependencies = [
  "bitflags",
  "x86_64",
@@ -70,9 +70,9 @@ checksum = "f6b06ad3ed06fef1713569d547cdbdb439eafed76341820fb0e0344f29a41945"
 
 [[package]]
 name = "x86_64"
-version = "0.11.8"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa1f02f6b33489502afe477f7d428cfa1eee22d4a10966e95dfeed96c523d46"
+checksum = "238a5798f77641af3c4f242bf985807f312a480cd4e35ed7255fad4b2ccb9d4f"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ bootloader = "0.9.8"
 rlibc = "1.0.0"
 volatile = "0.2.6"
 spin = "0.5.2"
-x86_64 = "0.11.0"
+x86_64 = "0.12.1"
 uart_16550 = "0.2.0"
 
 [dependencies.lazy_static]


### PR DESCRIPTION
Fixes build on latest nightly.

Also updates the `uart_16550` dependency.