### PR TITLE
Use new `const_mut_refs` feature gate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![feature(custom_test_frameworks)]
 #![feature(abi_x86_interrupt)]
 #![feature(alloc_error_handler)]
-#![feature(const_fn)]
+#![feature(const_mut_refs)]
 #![feature(const_in_array_repeat_expressions)]
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]


### PR DESCRIPTION
Fixes the build on the latest Rust nightly.﻿
