### PR TITLE
Update to zola v0.12.1

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: 'Download Zola'
-      run: curl -sL https://github.com/getzola/zola/releases/download/v0.11.0/zola-v0.11.0-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+      run: curl -sL https://github.com/getzola/zola/releases/download/v0.12.1/zola-v0.12.1-x86_64-unknown-linux-gnu.tar.gz | tar zxv
     - name: "Install Python Tools"
       run: python -m pip install --upgrade pip setuptools wheel
     - name: 'Install Python Libraries'
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: 'Download Zola'
-      run: curl -sL https://github.com/getzola/zola/releases/download/v0.11.0/zola-v0.11.0-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+      run: curl -sL https://github.com/getzola/zola/releases/download/v0.12.1/zola-v0.12.1-x86_64-unknown-linux-gnu.tar.gz | tar zxv
 
     - name: "Run zola check"
       run: ../zola check

--- a/blog/templates/first-edition/comments.html
+++ b/blog/templates/first-edition/comments.html
@@ -1,29 +1,29 @@
 {% macro comment(page) %}
-    {% if page.path == "multiboot-kernel/" %}
+    {% if page.path == "/multiboot-kernel/" %}
         {% include "first-edition/comments/multiboot-kernel.html" %}
-    {% elif page.path == "entering-longmode/" %}
+    {% elif page.path == "/entering-longmode/" %}
         {% include "first-edition/comments/entering-longmode.html" %}
-    {% elif page.path == "set-up-rust/" %}
+    {% elif page.path == "/set-up-rust/" %}
         {% include "first-edition/comments/set-up-rust.html" %}
-    {% elif page.path == "printing-to-screen/" %}
+    {% elif page.path == "/printing-to-screen/" %}
         {% include "first-edition/comments/printing-to-screen.html" %}
-    {% elif page.path == "allocating-frames/" %}
+    {% elif page.path == "/allocating-frames/" %}
         {% include "first-edition/comments/allocating-frames.html" %}
-    {% elif page.path == "page-tables/" %}
+    {% elif page.path == "/page-tables/" %}
         {% include "first-edition/comments/page-tables.html" %}
-    {% elif page.path == "remap-the-kernel/" %}
+    {% elif page.path == "/remap-the-kernel/" %}
         {% include "first-edition/comments/remap-the-kernel.html" %}
-    {% elif page.path == "kernel-heap/" %}
+    {% elif page.path == "/kernel-heap/" %}
         {% include "first-edition/comments/kernel-heap.html" %}
-    {% elif page.path == "handling-exceptions/" %}
+    {% elif page.path == "/handling-exceptions/" %}
         {% include "first-edition/comments/handling-exceptions.html" %}
-    {% elif page.path == "double-faults/" %}
+    {% elif page.path == "/double-faults/" %}
         {% include "first-edition/comments/double-faults.html" %}
-    {% elif page.path == "catching-exceptions/" %}
+    {% elif page.path == "/catching-exceptions/" %}
         {% include "first-edition/comments/catching-exceptions.html" %}
-    {% elif page.path == "better-exception-messages/" %}
+    {% elif page.path == "/better-exception-messages/" %}
         {% include "first-edition/comments/better-exception-messages.html" %}
-    {% elif page.path == "returning-from-exceptions/" %}
+    {% elif page.path == "/returning-from-exceptions/" %}
         {% include "first-edition/comments/returning-from-exceptions.html" %}
     {% else %}
         No comments.

--- a/blog/templates/first-edition/index.html
+++ b/blog/templates/first-edition/index.html
@@ -19,7 +19,7 @@
     </p>
     <p>Latest post:
         {% set latest_post = posts|last %}
-        <strong><a href="/{{ latest_post.path | safe }}">{{ latest_post.title }}</a></strong>
+        <strong><a href="{{ latest_post.path | safe }}">{{ latest_post.title }}</a></strong>
     </p>
 </div>
 
@@ -55,10 +55,10 @@
 <ul>
     {% for subsection_path in extra.subsections %}
         {% set subsection = get_section(path=subsection_path) %}
-        <li><a href="/{{ subsection.path | safe }}">{{ subsection.title }}</a></li>
+        <li><a href="{{ subsection.path | safe }}">{{ subsection.title }}</a></li>
     {% endfor %}
     {% for page in extra.pages %}
-        <li><a href="/{{ page.path | safe }}">{{ page.title }}</a></li>
+        <li><a href="{{ page.path | safe }}">{{ page.title }}</a></li>
     {% endfor %}
 </ul>
 

--- a/blog/templates/first-edition/page.html
+++ b/blog/templates/first-edition/page.html
@@ -36,10 +36,10 @@
     <hr>
     <div class="PageNavigation">
         {% if page.lighter %}
-            <a class="prev" href="/{{ page.lighter.path | safe }}">&laquo; {{ page.lighter.title }}</a>
+            <a class="prev" href="{{ page.lighter.path | safe }}">&laquo; {{ page.lighter.title }}</a>
         {% endif %}
         {% if page.heavier %}
-            <a class="next" href="/{{ page.heavier.path | safe }}">{{ page.heavier.title }} &raquo;</a>
+            <a class="next" href="{{ page.heavier.path | safe }}">{{ page.heavier.title }} &raquo;</a>
         {% endif %}
     </div>
 

--- a/blog/templates/macros.html
+++ b/blog/templates/macros.html
@@ -7,10 +7,10 @@
             {%- set post = page -%}
             {%- set not_translated = true -%}
         {%- endif -%}
-        <h2 class="post-title"><a href="/{{ post.path | safe }}">{{ post.title }}</a></h2>
+        <h2 class="post-title"><a href="{{ post.path | safe }}">{{ post.title }}</a></h2>
         <div class="post-summary">
             {{ post.summary | safe }}
-            <a class="read-more" href="/{{ post.path | safe }}"><em>read&nbsp;more&nbsp;»</em></a>
+            <a class="read-more" href="{{ post.path | safe }}"><em>read&nbsp;more&nbsp;»</em></a>
 
             {%- if lang and not_translated and lang != config.default_language -%}
             <aside class="no-translation">

--- a/blog/templates/news-section.html
+++ b/blog/templates/news-section.html
@@ -13,13 +13,13 @@
 <div class="posts neutral">
     {% for page in section.pages %}
         <div>
-            <h2 class="post-title"><a href="/{{ page.path | safe }}">{{ page.title }}</a></h2>
+            <h2 class="post-title"><a href="{{ page.path | safe }}">{{ page.title }}</a></h2>
             <time datetime="{{ page.date | date(format="%Y-%m-%d") }}" class="post-date" style="margin-bottom: 0.5rem;">
                     {{ page.date | date(format="%b %d, %Y") }}
             </time>
             <div class="post-summary" style="margin-bottom: 2rem;">
                 {{ page.summary | safe}}
-                <a class="read-more" href="/{{ page.path | safe }}">read more…</a>
+                <a class="read-more" href="{{ page.path | safe }}">read more…</a>
             </div>
         </div>
     {% endfor %}

--- a/blog/templates/second-edition/index.html
+++ b/blog/templates/second-edition/index.html
@@ -19,7 +19,7 @@
     </p>
     <p>Latest post:
         {% set latest_post = posts|last %}
-        <strong><a href="/{{ latest_post.path | safe }}">{{ latest_post.title }}</a></strong>
+        <strong><a href="{{ latest_post.path | safe }}">{{ latest_post.title }}</a></strong>
     </p>
 </div>
 
@@ -66,7 +66,7 @@
 
 <div class="frontpage-section">
     <h2 class="post-title">First Edition</h2>
-    <p>You are currently viewing the second edition of “Writing an OS in Rust”. The first edition is very different in many aspects, for example it builds upon the GRUB bootloader instead of using the `bootloader` crate. In case you're interested in it, it is still available. Note that the first edition is no longer updated and might contain outdated information. <a class="read-more" href="{{ get_url(path = "/first-edition") | safe }}"><em>read&nbsp;the&nbsp;first edition&nbsp;»</em></a></p>
+    <p>You are currently viewing the second edition of “Writing an OS in Rust”. The first edition is very different in many aspects, for example it builds upon the GRUB bootloader instead of using the `bootloader` crate. In case you're interested in it, it is still available. Note that the first edition is no longer updated and might contain outdated information. <a class="read-more" href="{{ get_url(path = "first-edition") | safe }}"><em>read&nbsp;the&nbsp;first edition&nbsp;»</em></a></p>
 </div>
 
 <div class="">

--- a/blog/templates/second-edition/page.html
+++ b/blog/templates/second-edition/page.html
@@ -77,10 +77,10 @@
     <hr>
     <div class="PageNavigation">
         {% if page.lighter %}
-            <a class="prev" href="/{{ page.lighter.path | safe }}">&laquo; {{ page.lighter.title }}</a>
+            <a class="prev" href="{{ page.lighter.path | safe }}">&laquo; {{ page.lighter.title }}</a>
         {% endif %}
         {% if page.heavier %}
-            <a class="next" href="/{{ page.heavier.path | safe }}">{{ page.heavier.title }} &raquo;</a>
+            <a class="next" href="{{ page.heavier.path | safe }}">{{ page.heavier.title }} &raquo;</a>
         {% endif %}
     </div>
 

--- a/blog/templates/status-update-page.html
+++ b/blog/templates/status-update-page.html
@@ -23,10 +23,10 @@
     <hr>
     <div class="PageNavigation">
         {% if page.earlier %}
-            <a class="prev" href="/{{ page.earlier.path | safe }}">&laquo; {{ page.earlier.title }}</a>
+            <a class="prev" href="{{ page.earlier.path | safe }}">&laquo; {{ page.earlier.title }}</a>
         {% endif %}
         {% if page.later %}
-            <a class="next" href="/{{ page.later.path | safe }}">{{ page.later.title }} &raquo;</a>
+            <a class="next" href="{{ page.later.path | safe }}">{{ page.later.title }} &raquo;</a>
         {% endif %}
     </div>
     <hr>

--- a/blog/templates/status-update-section.html
+++ b/blog/templates/status-update-section.html
@@ -15,7 +15,7 @@
 <div><ul>
     {% include "auto/status-updates.html" %}
     {% for page in section.pages %}
-        <li><b><a href="/{{ page.path | safe }}">{{ page.title }}</a></b></li>
+        <li><b><a href="{{ page.path | safe }}">{{ page.title }}</a></b></li>
     {% endfor %}
 </ul></div>
 


### PR DESCRIPTION
This updates `zola`, the static site generator that we use, to version 0.12.1.

There is only one breaking change between version 0.11.0 (our current version) and 0.12.1 that affects us: Page paths now have a leading `/`. This means that we have to remove our manual `/`s in templates to avoid double `//` in the generated code.

I'm most excited about the new support for line highlighting in code blocks, which was added in https://github.com/getzola/zola/pull/1131. This should allow us to properly highlight the lines currently marked with a `// new` comment in our code excerpts.
