### PR TITLE
Use shorthand initialization from earlier code

### DIFF
--- a/blog/content/second-edition/posts/03-vga-text-buffer/index.md
+++ b/blog/content/second-edition/posts/03-vga-text-buffer/index.md
@@ -339,7 +339,7 @@ impl Writer {
 
                 self.buffer.chars[row][col].write(ScreenChar {
                     ascii_character: byte,
-                    color_code: color_code,
+                    color_code,
                 });
                 ...
             }


### PR DESCRIPTION
Minor change, but keep the shorthand struct initialization seen previously at line 201: https://github.com/phil-opp/blog_os/blame/master/blog/content/second-edition/posts/03-vga-text-buffer/index.md#L201