### PR TITLE
Remove rlibc and use compiler-builtins-mem feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [unstable]
 build-std = ["core", "compiler_builtins"]
+build-std-features = ["compiler-builtins-mem"]
 
 [build]
 target = "x86_64-blog_os.json"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,6 @@ name = "blog_os"
 version = "0.1.0"
 dependencies = [
  "bootloader",
- "rlibc",
 ]
 
 [[package]]
@@ -13,9 +12,3 @@ name = "bootloader"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83732ad599045a978528e4311539fdcb20c30e406b66d1d08cd4089d4fc8d90f"
-
-[[package]]
-name = "rlibc"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2018"
 
 [dependencies]
 bootloader = "0.9.8"
-rlibc = "1.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate rlibc;
-
 use core::panic::PanicInfo;
 
 static HELLO: &[u8] = b"Hello World!";


### PR DESCRIPTION
Part of #862

I can also remove the references to `rlibc` from the blog posts if that saves you time