### PR TITLE
Update post-04 to use compiler_builtins `mem` feature instead of `rlibc`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [unstable]
 build-std = ["core", "compiler_builtins"]
+build-std-features = ["compiler-builtins-mem"]
 
 [build]
 target = "x86_64-blog_os.json"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,6 @@ version = "0.1.0"
 dependencies = [
  "bootloader",
  "lazy_static",
- "rlibc",
  "spin",
  "uart_16550",
  "volatile",
@@ -39,12 +38,6 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "rlibc"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ harness = false
 
 [dependencies]
 bootloader = "0.9.8"
-rlibc = "1.0.0"
 volatile = "0.2.6"
 spin = "0.5.2"
 x86_64 = "0.12.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
-extern crate rlibc;
-
 use core::panic::PanicInfo;
 
 pub mod serial;


### PR DESCRIPTION
Update `post-04` branch for changes introduced in https://github.com/phil-opp/blog_os/pull/865.