### PR TITLE
Specify which file to change for Memory-Related Intrinsics

### DIFF
--- a/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/second-edition/posts/02-minimal-rust-kernel/index.md
@@ -300,6 +300,8 @@ Fortunately, the `compiler_builtins` crate already contains implementations for 
 [`build-std-features`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std-features
 
 ```toml
+# in .cargo/config.toml
+
 [unstable]
 build-std-features = ["compiler-builtins-mem"]
 ```


### PR DESCRIPTION
The commented file path was removed in https://github.com/phil-opp/blog_os/pull/866

This matches the other code snippet additions to `.cargo/config.toml` and `Cargo.toml`, and I was personally tripped up by it 😣 