### PR TITLE
Emphasize moving code

### DIFF
--- a/blog/content/second-edition/posts/04-testing/index.md
+++ b/blog/content/second-edition/posts/04-testing/index.md
@@ -687,7 +687,7 @@ To make the required functions available to our integration test, we need to spl
 
 Like the `main.rs`, the `lib.rs` is a special file that is automatically recognized by cargo. The library is a separate compilation unit, so we need to specify the `#![no_std]` attribute again.
 
-To make our library work with `cargo test`, we need to also add the test functions and attributes:
+To make our library work with `cargo test`, we need to also move the test functions and attributes to `lib.rs` from `main.rs`:
 
 ```rust
 // in src/lib.rs

--- a/blog/content/second-edition/posts/04-testing/index.md
+++ b/blog/content/second-edition/posts/04-testing/index.md
@@ -687,7 +687,7 @@ To make the required functions available to our integration test, we need to spl
 
 Like the `main.rs`, the `lib.rs` is a special file that is automatically recognized by cargo. The library is a separate compilation unit, so we need to specify the `#![no_std]` attribute again.
 
-To make our library work with `cargo test`, we need to also move the test functions and attributes to `lib.rs` from `main.rs`:
+To make our library work with `cargo test`, we need to also move the test functions and attributes from `main.rs`  to `lib.rs`:
 
 ```rust
 // in src/lib.rs

--- a/blog/content/second-edition/posts/04-testing/index.zh-CN.md
+++ b/blog/content/second-edition/posts/04-testing/index.zh-CN.md
@@ -613,7 +613,7 @@ fn panic(info: &PanicInfo) -> ! {
 
 和`main.rs`一样，`lib.rs`也是一个可以被cargo自动识别的特殊文件。该库是一个独立的编译单元，所以我们需要再次指定`#![no_std]` 属性。
 
-为了让我们的库可以和`cargo xtest`一起协同工作，我们还需要添加以下测试函数和属性:
+为了让我们的库可以和`cargo xtest`一起协同工作，我们还需要移动以下测试函数和属性:
 
 ```rust
 // in src/lib.rs


### PR DESCRIPTION
This prevents people from having duplicate code and potentially encountering errors. If both copies are kept the compiler may complain `error: cannot find macro `serial_println` in this scope` in `main.rs`