### PR TITLE
Fix broken QEMU link

### DIFF
--- a/blog/content/second-edition/posts/deprecated/05-integration-tests/index.md
+++ b/blog/content/second-edition/posts/deprecated/05-integration-tests/index.md
@@ -179,7 +179,7 @@ bootimage run -- -serial mon:stdio
 
 Instead of standard output, QEMU supports [many more target devices][QEMU -serial]. For redirecting the output to a file, the argument is:
 
-[QEMU -serial]: https://qemu.weilnetz.de/doc/latest/system/invocation.html#hxtool-9
+[QEMU -serial]: https://qemu.weilnetz.de/doc/5.2/system/invocation.html#hxtool-9
 
 ```
 -serial file:output-file.txt


### PR DESCRIPTION
Use specified version instead (it'd be great if Zola could ignore some paths on link-checker, I imagine).