### PR TITLE
fix layout of right-to-left in homepage and tables

### DIFF
--- a/blog/static/css/edition-2/main.css
+++ b/blog/static/css/edition-2/main.css
@@ -454,6 +454,6 @@ a strong {
 	direction: rtl;
 }
 
-.left-to-right, .right-to-left pre {
+.left-to-right, .right-to-left pre, .right-to-left table {
 	direction: ltr;
 }

--- a/blog/templates/macros.html
+++ b/blog/templates/macros.html
@@ -1,12 +1,12 @@
 {% macro post_link(page) %}
-    <div>
-        {% set translations = page.translations | filter(attribute="lang", value=lang) -%}
-        {%- if translations -%}
-            {%- set post = get_page(path = translations.0.path) -%}
-        {%- else -%}
-            {%- set post = page -%}
-            {%- set not_translated = true -%}
-        {%- endif -%}
+    {% set translations = page.translations | filter(attribute="lang", value=lang) -%}
+    {%- if translations -%}
+        {%- set post = get_page(path = translations.0.path) -%}
+    {%- else -%}
+        {%- set post = page -%}
+        {%- set not_translated = true -%}
+    {%- endif -%}
+    <div{% if post.extra.rtl %} class="right-to-left"{% endif %}>
         <h2 class="post-title"><a href="{{ post.path | safe }}">{{ post.title }}</a></h2>
         <div class="post-summary">
             {{ post.summary | safe }}


### PR DESCRIPTION
The layout of Home page had problem showing right-to-left texts so i fixed it.
Also tables in posts that are right-to-left had the same issue causing show them incorrectly.