### PR TITLE
remove unused import

### DIFF
--- a/blog/content/edition-2/posts/10-heap-allocation/index.md
+++ b/blog/content/edition-2/posts/10-heap-allocation/index.md
@@ -715,8 +715,6 @@ Now we're ready to add a few test cases. First, we add a test that performs some
 
 ```rust
 // in tests/heap_allocation.rs
-
-use blog_os::{serial_print, serial_println};
 use alloc::boxed::Box;
 
 #[test_case]


### PR DESCRIPTION
Removes the unused imports of serial_print/ln from heap allocation example code 