### PR TITLE
Added note to specify version 0.2.6 of volatile

### DIFF
--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.md
@@ -305,8 +305,7 @@ We can add a dependency on the `volatile` crate by adding it to the `dependencie
 volatile = "0.2.6"
 ```
 
-Make sure to specify `volatile` version `0.2.6`. We will run into errors using later versions of the crate.
-
+Make sure to specify `volatile` version `0.2.6`. Newer versions of the crate are not compatible with this post.
 The `0.2.6` is the [semantic] version number. For more information, see the [Specifying Dependencies] guide of the cargo documentation.
 
 [semantic]: https://semver.org/

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.md
@@ -305,6 +305,8 @@ We can add a dependency on the `volatile` crate by adding it to the `dependencie
 volatile = "0.2.6"
 ```
 
+Make sure to specifiy `volatile` version `0.2.6`. We will run into errors using later versions of the crate.
+
 The `0.2.6` is the [semantic] version number. For more information, see the [Specifying Dependencies] guide of the cargo documentation.
 
 [semantic]: https://semver.org/

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.md
@@ -305,7 +305,7 @@ We can add a dependency on the `volatile` crate by adding it to the `dependencie
 volatile = "0.2.6"
 ```
 
-Make sure to specifiy `volatile` version `0.2.6`. We will run into errors using later versions of the crate.
+Make sure to specify `volatile` version `0.2.6`. We will run into errors using later versions of the crate.
 
 The `0.2.6` is the [semantic] version number. For more information, see the [Specifying Dependencies] guide of the cargo documentation.
 


### PR DESCRIPTION
Added explicit note to specify `volatile` crate version `0.2.6`, since later versions produce an error.