### PR TITLE
Fix typo

### DIFF
--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.zh-CN.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.zh-CN.md
@@ -109,7 +109,7 @@ Nightly 版本的编译器允许我们在源码的开头插入**特性标签**�
     "target-pointer-width": "64",
     "target-c-int-width": "32",
     "os": "none",
-    "executables": true,
+    "executables": true
 }
 ```
 


### PR DESCRIPTION
Hi. There was a trivial JSON tailing comma problem in edition-2, post-02, zh-CN(only). So I fixed that for consistency across languages.