### PR TITLE
Update x86_64 dependency to v0.13.2 to fix nightly breakage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "uart_16550"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07777999215cbf8772f7974116039b439b1bddb90302d293c5a578d1d3a763d"
+checksum = "8d45a3c9181dc9ba7d35d02b3c36d1604155289d935b7946510fb3d2f4b976d9"
 dependencies = [
  "bitflags",
  "x86_64",
@@ -63,9 +63,9 @@ checksum = "f6b06ad3ed06fef1713569d547cdbdb439eafed76341820fb0e0344f29a41945"
 
 [[package]]
 name = "x86_64"
-version = "0.12.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b4b42dbabe13b69023e1a1407d395f1a1a33df76e9a9efdbe303acc907e292"
+checksum = "b871116e3c83dad0795580b10b2b1dd05cb52ec719af36180371877b09681f7f"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ harness = false
 bootloader = "0.9.8"
 volatile = "0.2.6"
 spin = "0.5.2"
-x86_64 = "0.12.1"
+x86_64 = "0.13.2"
 uart_16550 = "0.2.0"
 
 [dependencies.lazy_static]


### PR DESCRIPTION
See https://github.com/rust-osdev/x86_64/pull/230