### PR TITLE
Use constant instead of removed `const_in_array_repeat_expressions` feature

### DIFF
--- a/src/allocator/fixed_size_block.rs
+++ b/src/allocator/fixed_size_block.rs
@@ -31,8 +31,9 @@ pub struct FixedSizeBlockAllocator {
 impl FixedSizeBlockAllocator {
     /// Creates an empty FixedSizeBlockAllocator.
     pub const fn new() -> Self {
+        const EMPTY: Option<&'static mut ListNode> = None;
         FixedSizeBlockAllocator {
-            list_heads: [None; BLOCK_SIZES.len()],
+            list_heads: [EMPTY; BLOCK_SIZES.len()],
             fallback_allocator: linked_list_allocator::Heap::empty(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(abi_x86_interrupt)]
 #![feature(alloc_error_handler)]
 #![feature(const_mut_refs)]
-#![feature(const_in_array_repeat_expressions)]
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 


### PR DESCRIPTION
The `const_in_array_repeat_expressions` feature was removed in https://github.com/rust-lang/rust/pull/80404 because its design led to various bugs. The inline const blocks (`const { ... }`) feature should be a good alternative, but it is still marked as incomplete because there are still major bugs with it too. For this reason, this PR uses a local `EMPTY` constant instead to not require any unstable features at all. 