### PR TITLE
The `enable_interrupts_and_hlt` function was renamed to `enable_and_hlt`

### DIFF
--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -62,11 +62,11 @@ impl Executor {
     }
 
     fn sleep_if_idle(&self) {
-        use x86_64::instructions::interrupts::{self, enable_interrupts_and_hlt};
+        use x86_64::instructions::interrupts::{self, enable_and_hlt};
 
         interrupts::disable();
         if self.task_queue.is_empty() {
-            enable_interrupts_and_hlt();
+            enable_and_hlt();
         } else {
             interrupts::enable();
         }


### PR DESCRIPTION
Fixes https://github.com/phil-opp/blog_os/issues/889.