### PR TITLE
Remove note on builtin memory optimizations

### DIFF
--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
@@ -310,12 +310,10 @@ build-std-features = ["compiler-builtins-mem"]
 
 (Support for the `compiler-builtins-mem` feature was only [added very recently](https://github.com/rust-lang/rust/pull/77284), so you need at least Rust nightly `2020-09-30` for it.)
 
-Behind the scenes, this flag enables the [`mem` feature] of the `compiler_builtins` crate. The effect of this is that the `#[no_mangle]` attribute is applied to the [`memcpy` etc. implementations] of the crate, which makes them available to the linker. It's worth noting that these functions are [not optimized] right now, so their performance might not be the best, but at least they are correct. For `x86_64`, there is an open pull request to [optimize these functions using special assembly instructions][memcpy rep movsb].
+Behind the scenes, this flag enables the [`mem` feature] of the `compiler_builtins` crate. The effect of this is that the `#[no_mangle]` attribute is applied to the [`memcpy` etc. implementations] of the crate, which makes them available to the linker.
 
 [`mem` feature]: https://github.com/rust-lang/compiler-builtins/blob/eff506cd49b637f1ab5931625a33cef7e91fbbf6/Cargo.toml#L54-L55
 [`memcpy` etc. implementations]: https://github.com/rust-lang/compiler-builtins/blob/eff506cd49b637f1ab5931625a33cef7e91fbbf6/src/mem.rs#L12-L69
-[not optimized]: https://github.com/rust-lang/compiler-builtins/issues/339
-[memcpy rep movsb]: https://github.com/rust-lang/compiler-builtins/pull/365
 
 With this change, our kernel has valid implementations for all compiler-required functions, so it will continue to compile even if our code gets more complex.
 


### PR DESCRIPTION
The referenced issue in compiler-builtins (https://github.com/rust-lang/compiler-builtins/pull/365) has been merged. Hence, I think it's safe to remove the note about the memory implementations not being optimized.

I'm not sure if you would want to state that the implementations are optimized - I think it's likely assumed by the reader unless otherwise stated.