### PR TITLE
Simplify the later example error

### DIFF
--- a/blog/content/edition-2/posts/12-async-await/index.md
+++ b/blog/content/edition-2/posts/12-async-await/index.md
@@ -549,6 +549,7 @@ Using heap allocation, we can try to create a self-referential struct:
 
 ```rust
 fn main() {
+    #[allow(unused_mut)]
     let mut heap_value = Box::new(SelfReferential {
         self_ptr: 0 as *const _,
     });


### PR DESCRIPTION
Required so that the current compiler output match the example error on line 637, (because the compiler is now clever enough to warn about):
```bash
warning: variable does not need to be mutable
 --> src/main.rs:5:9
  |
5 |     let mut heap_value = Box::pin(SelfReferential {
  |         ----^^^^^^^^^^
  |         |
  |         help: remove this `mut`
  |
  = note: `#[warn(unused_mut)]` on by default
```
Which is distracting. (Also a chance to passively introduce `#[allow(unused_mut)]` )  

Though this proposed change may, in itself be a distraction for the student?