### PR TITLE
Suggestion for .cargo/config.toml Explanation

### DIFF
--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
@@ -306,6 +306,7 @@ Fortunately, the `compiler_builtins` crate already contains implementations for 
 
 [unstable]
 build-std-features = ["compiler-builtins-mem"]
+build-std = ["core", "compiler_builtins"]
 ```
 
 (Support for the `compiler-builtins-mem` feature was only [added very recently](https://github.com/rust-lang/rust/pull/77284), so you need at least Rust nightly `2020-09-30` for it.)


### PR DESCRIPTION
I was confused on what the 'unstable' section of my .cargo/config.toml file should look like once I started getting linking errors when going through the third post. It turned out it was because I overwrote the previous 'unstable' configuration with the latter one. 

In other words, I thought we were to overwrite "build-std = ["core", "compiler_builtins"]" under the "unstable" config, with "build-std-features = ["compiler-builtins-mem"]" and NOT have both present. 

I think this makes it more clear that both are supposed to be present.