### PR TITLE
Update x86_64 dependency to v0.14.2 to fix nightly breakage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "spin",
  "uart_16550",
  "volatile 0.2.7",
- "x86_64 0.13.6",
+ "x86_64",
 ]
 
 [[package]]
@@ -54,7 +54,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "503a6c0e6d82daa87985e662d120c0176b09587c92a68db22781b28ae95405dd"
 dependencies = [
  "bitflags",
- "x86_64 0.14.2",
+ "x86_64",
 ]
 
 [[package]]
@@ -68,16 +68,6 @@ name = "volatile"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c2dbd44eb8b53973357e6e207e370f0c1059990df850aca1eca8947cf464f0"
-
-[[package]]
-name = "x86_64"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021b49a4cb0a0d9490265cc169ca816014cbf61d3f3b75424815912977b81871"
-dependencies = [
- "bit_field",
- "bitflags",
-]
 
 [[package]]
 name = "x86_64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ harness = false
 bootloader = "0.9.8"
 volatile = "0.2.6"
 spin = "0.5.2"
-x86_64 = "0.13.2"
+x86_64 = "0.14.2"
 uart_16550 = "0.2.0"
 
 [dependencies.lazy_static]


### PR DESCRIPTION
Updates the `post-04` branch.