### PR TITLE
Switch comments from utterances to giscus

### DIFF
--- a/blog/static/css/edition-2/main.css
+++ b/blog/static/css/edition-2/main.css
@@ -462,3 +462,11 @@ a strong {
 .status-update-list li {
   margin-bottom: .5rem;
 }
+
+#comments {
+  visibility: hidden;
+}
+
+.comment-directly-on-github {
+  margin-top: 1rem;
+}

--- a/blog/templates/edition-2/base.html
+++ b/blog/templates/edition-2/base.html
@@ -20,6 +20,8 @@
     <script async src="/js/edition-2/main.js"></script>
 
     <title>{% block title %}{% endblock title %}</title>
+
+    {% block head %}{% endblock head %}
 </head>
 
 <body>

--- a/blog/templates/edition-2/extra.html
+++ b/blog/templates/edition-2/extra.html
@@ -3,6 +3,7 @@
 {% import "snippets.html" as snippets %}
 
 {% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
+{% block head %}<meta property="og:title" content="{{ page.title }}" />{% endblock head %}
 
 {% block description -%}
 {{ page.summary | safe | striptags | truncate(length=150) }}
@@ -16,7 +17,7 @@
 {% block after_main %}
     <hr>
     <section>
-        <h2>Comments</h2>
-        {{ snippets::utterances() }}
+        <h2 id="comments">Comments</h2>
+        {{ snippets::giscus() }}
     </section>
 {% endblock after_main %}

--- a/blog/templates/edition-2/page.html
+++ b/blog/templates/edition-2/page.html
@@ -4,6 +4,8 @@
 {% import "snippets.html" as snippets %}
 
 {% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
+{% block head %}<meta property="og:title" content="{{ page.title }}" />{% endblock head %}
+
 {% block header %}
     {% if lang != "en" -%}
     <aside id="all-posts-link"><a href="{{ config.base_url | safe }}/{{ lang }}" title="All Posts">{{ trans(key="all_posts", lang=lang) }}</a></aside>
@@ -102,7 +104,7 @@
         </p>
         {% endif %}
 
-        {{ snippets::utterances() }}
+        {{ snippets::giscus() }}
     </section>
 
     <aside class="page-aside-right">

--- a/blog/templates/news-page.html
+++ b/blog/templates/news-page.html
@@ -3,6 +3,7 @@
 {% import "snippets.html" as snippets %}
 
 {% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
+{% block head %}<meta property="og:title" content="{{ page.title }}" />{% endblock head %}
 
 {% block main %}
     <h1>{{ page.title }}</h1>
@@ -17,7 +18,7 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::utterances() }}
+        {{ snippets::giscus() }}
     </section>
 
 {% endblock after_main %}

--- a/blog/templates/snippets.html
+++ b/blog/templates/snippets.html
@@ -10,12 +10,28 @@
 </p>
 {% endmacro support %}
 
-{% macro utterances() %}
-    <script src="https://utteranc.es/client.js"
+{% macro giscus(discussion_number=0) %}
+    <div class="giscus"></div>
+
+    {% if discussion_number == 0 %}
+        {% set discussion_mapping="og:title" %}
+    {% else %}
+        {% set discussion_mapping="number" %}
+    {% endif %}
+
+    <script src="https://giscus.app/client.js"
         data-repo="phil-opp/blog_os"
-        data-issue-term="url"
-        data-label="comments"
+        data-repo-id="MDEwOlJlcG9zaXRvcnkzOTU3NTEwMQ=="
+        data-category="Post Comments"
+        data-category-id="MDE4OkRpc2N1c3Npb25DYXRlZ29yeTMzMDE4OTg1"
+        data-mapping="og:title"
+        data-reactions-enabled="1"
+        data-theme="preferred_color_scheme"
         crossorigin="anonymous"
         async>
     </script>
-{% endmacro utterances %}
+
+    <p class="comment-directly-on-github">
+        Instead of authenticating the <a href="https://giscus.app">giscus</a> application, you can also comment directly on the <span class="discussion_link">on GitHub. Just click the <i>"X comments"</i> link at the <a href="#comments">top</a> — or the date of any comment — to go to the GitHub discussion.</span>
+    </p>
+{% endmacro giscus %}

--- a/blog/templates/status-update-page.html
+++ b/blog/templates/status-update-page.html
@@ -3,6 +3,7 @@
 {% import "snippets.html" as snippets %}
 
 {% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
+{% block head %}<meta property="og:title" content="{{ page.title }}" />{% endblock head %}
 
 {% block main %}
     <h1>{{ page.title }}</h1>
@@ -32,7 +33,7 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::utterances() }}
+        {{ snippets::giscus() }}
     </section>
 
 {% endblock after_main %}


### PR DESCRIPTION
To use GitHub discussions instead of issues for comment threads.

Requires migrating all comment threads to discussions.
