### PR TITLE
giscus: Use specific search term instead of `og:title`

### DIFF
--- a/blog/templates/edition-2/base.html
+++ b/blog/templates/edition-2/base.html
@@ -20,8 +20,6 @@
     <script async src="/js/edition-2/main.js"></script>
 
     <title>{% block title %}{% endblock title %}</title>
-
-    {% block head %}{% endblock head %}
 </head>
 
 <body>

--- a/blog/templates/edition-2/extra.html
+++ b/blog/templates/edition-2/extra.html
@@ -3,7 +3,6 @@
 {% import "snippets.html" as snippets %}
 
 {% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
-{% block head %}<meta property="og:title" content="{{ page.title }}" />{% endblock head %}
 
 {% block description -%}
 {{ page.summary | safe | striptags | truncate(length=150) }}
@@ -18,6 +17,6 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus() }}
+        {{ snippets::giscus(search_term=page.title ~ " (Extra Post)") }}
     </section>
 {% endblock after_main %}

--- a/blog/templates/edition-2/page.html
+++ b/blog/templates/edition-2/page.html
@@ -4,7 +4,6 @@
 {% import "snippets.html" as snippets %}
 
 {% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
-{% block head %}<meta property="og:title" content="{{ page.title }}" />{% endblock head %}
 
 {% block header %}
     {% if lang != "en" -%}
@@ -104,7 +103,7 @@
         </p>
         {% endif %}
 
-        {{ snippets::giscus() }}
+        {{ snippets::giscus(search_term=page.title) }}
     </section>
 
     <aside class="page-aside-right">

--- a/blog/templates/news-page.html
+++ b/blog/templates/news-page.html
@@ -3,7 +3,6 @@
 {% import "snippets.html" as snippets %}
 
 {% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
-{% block head %}<meta property="og:title" content="{{ page.title }}" />{% endblock head %}
 
 {% block main %}
     <h1>{{ page.title }}</h1>
@@ -18,7 +17,7 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus() }}
+        {{ snippets::giscus(search_term=page.title ~ " (News Post)") }}
     </section>
 
 {% endblock after_main %}

--- a/blog/templates/snippets.html
+++ b/blog/templates/snippets.html
@@ -10,21 +10,16 @@
 </p>
 {% endmacro support %}
 
-{% macro giscus(discussion_number=0) %}
+{% macro giscus(search_term) %}
     <div class="giscus"></div>
-
-    {% if discussion_number == 0 %}
-        {% set discussion_mapping="og:title" %}
-    {% else %}
-        {% set discussion_mapping="number" %}
-    {% endif %}
 
     <script src="https://giscus.app/client.js"
         data-repo="phil-opp/blog_os"
         data-repo-id="MDEwOlJlcG9zaXRvcnkzOTU3NTEwMQ=="
         data-category="Post Comments"
         data-category-id="MDE4OkRpc2N1c3Npb25DYXRlZ29yeTMzMDE4OTg1"
-        data-mapping="og:title"
+        data-mapping="specific"
+        data-term="{{ search_term }}"
         data-reactions-enabled="1"
         data-theme="preferred_color_scheme"
         crossorigin="anonymous"

--- a/blog/templates/status-update-page.html
+++ b/blog/templates/status-update-page.html
@@ -3,7 +3,6 @@
 {% import "snippets.html" as snippets %}
 
 {% block title %}{{ page.title }} | {{ config.title }}{% endblock title %}
-{% block head %}<meta property="og:title" content="{{ page.title }}" />{% endblock head %}
 
 {% block main %}
     <h1>{{ page.title }}</h1>
@@ -33,7 +32,7 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus() }}
+        {{ snippets::giscus(search_term=page.title) }}
     </section>
 
 {% endblock after_main %}


### PR DESCRIPTION
This makes us more flexible and gives us ways to avoid title collisions (e.g. when the title on an extra post is a substring of some post title).
