### PR TITLE
missing use blog_os::serial_println; in example

### DIFF
--- a/blog/content/edition-2/posts/04-testing/index.md
+++ b/blog/content/edition-2/posts/04-testing/index.md
@@ -985,6 +985,7 @@ Now we vastly simplify our `should_panic` test by removing the test runner relat
 
 use core::panic::PanicInfo;
 use blog_os::{exit_qemu, serial_print, serial_println, QemuExitCode};
+use blog_os::serial_println;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {


### PR DESCRIPTION
I noticed while following along that I was not able to run cargo test due to a missing `serial_println` in `should_panic.rs`

```
serial_print!("should_panic::should_fail...\t");
   |   ^^^^^^^^^^^^ help: a macro with a similar name exists: `serial_println`
```

I went ahead and added it in and things seemed to work just fine.