### PR TITLE
Add additional “real hardware” instructions

### DIFF
--- a/blog/content/edition-3/posts/02-booting/index.md
+++ b/blog/content/edition-3/posts/02-booting/index.md
@@ -633,7 +633,18 @@ TODO
 
 To boot on real hardware, you first need to write either the `bootimage-uefi-blog_os.img` or the `bootimage-bios-blog_os.img` disk image to an USB stick. This deletes everything on the stick, so be careful. The actual steps to do this depend on your operating system. 
 
-#### Linux
+#### Unix-like
+
+On any Unix-like host OS (including both Linux and macOS), you can use the `dd` command to write the disk image directly to a USB drive. First run either `sudo fdisk -l` (on Linux) or `diskutil list` on a Mac to get info about where in `/dev` the file representing your device is located. After that, open a terminal window and run either of the following commands:
+
+```
+# Linux
+$ sudo dd if=boot-uefi-blog_os.img of=/dev/sdb #replace with device filename as revealed by "sudo fdisk -l"
+# macOS
+$ sudo dd if=boot-uefi-blog_os.img of=/dev/disk4 #replace with device filename as revealed by "diskutil list"
+```
+
+**WARNING**: Be very careful when running this command. If you specify the wrong device as the `of=` parameter, you could end up wiping your system clean, so make sure the device you run it on is a removable one.
 
 #### Windows
 
@@ -641,10 +652,6 @@ On Windows, you can use the [Rufus] tool, which is developed as an open-source p
 
 [Rufus]: https://rufus.ie/
 [rufus-github]: https://github.com/pbatard/rufus
-
-#### macOS
-
-TODO
 
 ## Support for `cargo run`
 


### PR DESCRIPTION
Because macOS and Linux are both Unix-like operating systems, they both have the `dd` command bundled. During my 13 years of having Linux as my daily driver desktop OS and 1 year of having a MacBook Pro on the side, I’ve used this command long enough to know that it definitely gets this job done. So, time to start contributing.