### PR TITLE
Replace “lorem ipsum” with TODO lists

### DIFF
--- a/blog/content/edition-3/posts/03-screen-output/index.md
+++ b/blog/content/edition-3/posts/03-screen-output/index.md
@@ -12,14 +12,14 @@ icon = '''<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi 
 </svg>'''
 +++
 
-Dolores qui incidunt sit fugiat amet consequatur. Qui ab vel et molestias ex nemo corporis consequatur. Quia consequuntur itaque sequi quia autem. Maxime vel quis maxime at. Tenetur eveniet velit dolor quidem temporibus tenetur.
+# TODO: provide lesson on setting up a kernel-mode `Logger`
 
 <!-- more -->
 
-Molestiae quidem ipsa nihil laboriosam sapiente laudantium quia. Praesentium et repudiandae minima voluptas et. Repellendus voluptatem distinctio enim et alias distinctio recusandae quos. Dolores ex eum culpa quo sunt sint voluptate voluptates. Facere unde sequi quo ea vel nihil. Rem deleniti repellat rem molestias
+# TODO: more
 
 <!-- toc -->
-Molestiae quidem ipsa nihil laboriosam sapiente laudantium quia. Praesentium et repudiandae minima voluptas et. Repellendus voluptatem distinctio enim et alias distinctio recusandae quos. Dolores ex eum culpa quo sunt sint voluptate voluptates. Facere unde sequi quo ea vel nihil. Rem deleniti repellat rem molestias
 
+# TODO: TOC
 
 <!-- TODO: update relative link in 02-booting/uefi/index.md when this post is finished -->

--- a/blog/content/edition-3/posts/04-keyboard-and-serial/index.md
+++ b/blog/content/edition-3/posts/04-keyboard-and-serial/index.md
@@ -13,11 +13,11 @@ icon = '''<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi 
 </svg>'''
 +++
 
-Dolores qui incidunt sit fugiat amet consequatur. Qui ab vel et molestias ex nemo corporis consequatur. Quia consequuntur itaque sequi quia autem. Maxime vel quis maxime at. Tenetur eveniet velit dolor quidem temporibus tenetur.
+# TODO: provide lesson on using the [x2apic](https://crates.io/crates/x2apic) crate to handle interrupts (including keystrokes)
 
 <!-- more -->
 
-Molestiae quidem ipsa nihil laboriosam sapiente laudantium quia. Praesentium et repudiandae minima voluptas et. Repellendus voluptatem distinctio enim et alias distinctio recusandae quos. Dolores ex eum culpa quo sunt sint voluptate voluptates. Facere unde sequi quo ea vel nihil. Rem deleniti repellat rem molestias
+# TODO: more
 
 <!-- toc -->
-Molestiae quidem ipsa nihil laboriosam sapiente laudantium quia. Praesentium et repudiandae minima voluptas et. Repellendus voluptatem distinctio enim et alias distinctio recusandae quos. Dolores ex eum culpa quo sunt sint voluptate voluptates. Facere unde sequi quo ea vel nihil. Rem deleniti repellat rem molestias
+# TODO: TOC

--- a/blog/content/edition-3/posts/05-simple-shell/index.md
+++ b/blog/content/edition-3/posts/05-simple-shell/index.md
@@ -13,11 +13,15 @@ icon = '''<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi 
 </svg>'''
 +++
 
-Dolores qui incidunt sit fugiat amet consequatur. Qui ab vel et molestias ex nemo corporis consequatur. Quia consequuntur itaque sequi quia autem. Maxime vel quis maxime at. Tenetur eveniet velit dolor quidem temporibus tenetur.
+# TODO
+1. Lesson on switching to user mode
+2. Use file system crates like [fatfs](crates.io/crates/fatfs) and/or [btrfs-no-std](https://crates.io/crates/btrfs-no-std) to read/write from disk
+3. Develop shell commands using the above
 
 <!-- more -->
 
-Molestiae quidem ipsa nihil laboriosam sapiente laudantium quia. Praesentium et repudiandae minima voluptas et. Repellendus voluptatem distinctio enim et alias distinctio recusandae quos. Dolores ex eum culpa quo sunt sint voluptate voluptates. Facere unde sequi quo ea vel nihil. Rem deleniti repellat rem molestias
+# TODO: More
 
 <!-- toc -->
-Molestiae quidem ipsa nihil laboriosam sapiente laudantium quia. Praesentium et repudiandae minima voluptas et. Repellendus voluptatem distinctio enim et alias distinctio recusandae quos. Dolores ex eum culpa quo sunt sint voluptate voluptates. Facere unde sequi quo ea vel nihil. Rem deleniti repellat rem molestias
+
+# TODO: TOC

--- a/blog/content/edition-3/posts/06-basic-games/index.md
+++ b/blog/content/edition-3/posts/06-basic-games/index.md
@@ -13,11 +13,15 @@ icon = '''<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi 
 </svg>'''
 +++
 
-Dolores qui incidunt sit fugiat amet consequatur. Qui ab vel et molestias ex nemo corporis consequatur. Quia consequuntur itaque sequi quia autem. Maxime vel quis maxime at. Tenetur eveniet velit dolor quidem temporibus tenetur.
+# TODO:
+1. Define basic geometry structures like `Rect` and use [embedded-graphics](https://crates.io/crates/embedded-graphics) to draw them on the screen
+2. Use 1 as the basis for a simple window manager
+3. Also use `embedded-graphics` to draw some more complex shapes
 
 <!-- more -->
 
-Molestiae quidem ipsa nihil laboriosam sapiente laudantium quia. Praesentium et repudiandae minima voluptas et. Repellendus voluptatem distinctio enim et alias distinctio recusandae quos. Dolores ex eum culpa quo sunt sint voluptate voluptates. Facere unde sequi quo ea vel nihil. Rem deleniti repellat rem molestias
+# TODO: More
 
 <!-- toc -->
-Molestiae quidem ipsa nihil laboriosam sapiente laudantium quia. Praesentium et repudiandae minima voluptas et. Repellendus voluptatem distinctio enim et alias distinctio recusandae quos. Dolores ex eum culpa quo sunt sint voluptate voluptates. Facere unde sequi quo ea vel nihil. Rem deleniti repellat rem molestias
+
+# TODO: TOC


### PR DESCRIPTION
The structure of the blog templates as they are currently is very vulnerable to feature creep because “lorem ipsum” doesn’t provide any details about what will be implemented or how it will be. Replacing it with a list of instructions will make it easier for the open source community as a whole to help.

In case this isn’t exactly how it’s planned, I did select the “Allow Edits By Maintainers” checkbox, with good reason.