### PR TITLE
Adding fix to make the test_runner functions pub

### DIFF
--- a/blog/content/edition-2/posts/04-testing/index.fa.md
+++ b/blog/content/edition-2/posts/04-testing/index.fa.md
@@ -77,7 +77,7 @@ error[E0463]: can't find crate for `test`
 #![test_runner(crate::test_runner)]
 
 #[cfg(test)]
-fn test_runner(tests: &[&dyn Fn()]) {
+pub fn test_runner(tests: &[&dyn Fn()]) {
     println!("Running {} tests", tests.len());
     for test in tests {
         test();

--- a/blog/content/edition-2/posts/04-testing/index.ja.md
+++ b/blog/content/edition-2/posts/04-testing/index.ja.md
@@ -81,7 +81,7 @@ error[E0463]: can't find crate for `test`
 #![test_runner(crate::test_runner)]
 
 #[cfg(test)]
-fn test_runner(tests: &[&dyn Fn()]) {
+pub fn test_runner(tests: &[&dyn Fn()]) {
     println!("Running {} tests", tests.len());
     for test in tests {
         test();

--- a/blog/content/edition-2/posts/04-testing/index.md
+++ b/blog/content/edition-2/posts/04-testing/index.md
@@ -73,7 +73,7 @@ To implement a custom test framework for our kernel, we add the following to our
 #![test_runner(crate::test_runner)]
 
 #[cfg(test)]
-fn test_runner(tests: &[&dyn Fn()]) {
+pub fn test_runner(tests: &[&dyn Fn()]) {
     println!("Running {} tests", tests.len());
     for test in tests {
         test();

--- a/blog/content/edition-2/posts/04-testing/index.zh-CN.md
+++ b/blog/content/edition-2/posts/04-testing/index.zh-CN.md
@@ -75,7 +75,7 @@ error[E0463]: can't find crate for `test`
 #![test_runner(crate::test_runner)]
 
 #[cfg(test)]
-fn test_runner(tests: &[&dyn Fn()]) {
+pub fn test_runner(tests: &[&dyn Fn()]) {
     println!("Running {} tests", tests.len());
     for test in tests {
         test();


### PR DESCRIPTION
I always got the following error message when I tried chapter 4:

```rust
error[E0463]: can't find crate for `test`

For more information about this error, try `rustc --explain E0463`.
error: could not compile `os` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```

After comparing your source code on branch `post_04` with my code, I found out that the issue was function signature of `test_runner`: My signature was without `pub`. Adding the `pub` fixed it for me.

**HINT:** I don't really know if this PR is "necessary" because I couldn't find anyone else in the comments who got the same problem. Could it be that it just happened on my machine?

Greetings from Kerlsruhe by the way :)