### PR TITLE
Replace deprecated inclusive pattern syntax

### DIFF
--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.zh-CN.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.zh-CN.md
@@ -213,7 +213,7 @@ impl Writer {
         for byte in s.bytes() {
             match byte {
                 // 可以是能打印的 ASCII 码字节，也可以是换行符
-                0x20...0x7e | b'\n' => self.write_byte(byte),
+                0x20..=0x7e | b'\n' => self.write_byte(byte),
                 // 不包含在上述范围之内的字节
                 _ => self.write_byte(0xfe),
             }


### PR DESCRIPTION
I am currently using rustc 1.61.0-nightly (10913c000 2022-03-03). The original English blog is correct but this translation is deprecated.