### PR TITLE
Set CS register with non-deprecated function

### DIFF
--- a/blog/content/edition-2/posts/06-double-faults/index.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.md
@@ -363,10 +363,9 @@ Now we can use the selectors to reload the `cs` segment register and load our `T
 // in src/gdt.rs
 
 pub fn init() {
-    use x86_64::instructions::segmentation::set_cs;
     use x86_64::instructions::tables::load_tss;
-// use x86_64::instructions::segmentation::set_cs;
-use x86_64::instructions::segmentation::{CS, Segment};
+    use x86_64::instructions::segmentation::{CS, Segment};
+    
     GDT.0.load();
     unsafe {
         CS::set_reg(GDT.1.code_selector);

--- a/blog/content/edition-2/posts/06-double-faults/index.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.md
@@ -368,7 +368,7 @@ pub fn init() {
 
     GDT.0.load();
     unsafe {
-        set_cs(GDT.1.code_selector);
+        CS::set_reg(GDT.1.code_selector);
         load_tss(GDT.1.tss_selector);
     }
 }

--- a/blog/content/edition-2/posts/06-double-faults/index.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.md
@@ -365,7 +365,8 @@ Now we can use the selectors to reload the `cs` segment register and load our `T
 pub fn init() {
     use x86_64::instructions::segmentation::set_cs;
     use x86_64::instructions::tables::load_tss;
-
+// use x86_64::instructions::segmentation::set_cs;
+use x86_64::instructions::segmentation::{CS, Segment};
     GDT.0.load();
     unsafe {
         CS::set_reg(GDT.1.code_selector);


### PR DESCRIPTION
set_cs is deprecated and CS::set_reg is preferred. Update the blog to reflect this change according to the docs.