### PR TITLE
Delete unnecessary brackets

### DIFF
--- a/blog/content/edition-2/posts/12-async-await/index.ja.md
+++ b/blog/content/edition-2/posts/12-async-await/index.ja.md
@@ -425,7 +425,7 @@ ExampleStateMachine::WaitingOnFooTxt(state) => {
                 };
                 *self = ExampleStateMachine::WaitingOnBarTxt(state);
             } else {
-                *self = ExampleStateMachine::End(EndState));
+                *self = ExampleStateMachine::End(EndState);
                 return Poll::Ready(content);
             }
         }
@@ -446,7 +446,7 @@ ExampleStateMachine::WaitingOnBarTxt(state) => {
     match state.bar_txt_future.poll(cx) {
         Poll::Pending => return Poll::Pending,
         Poll::Ready(bar_txt) => {
-            *self = ExampleStateMachine::End(EndState));
+            *self = ExampleStateMachine::End(EndState);
             // from body of `example`
             return Poll::Ready(state.content + &bar_txt);
         }


### PR DESCRIPTION
## summary
Unnecessary parentheses were removed.

## corresponding section
Before change
```
*self = ExampleStateMachine::End(EndState));
```

After change
```
*self = ExampleStateMachine::End(EndState);
```