### PR TITLE
Move comment threads for translated posts to separate category

### DIFF
--- a/blog/templates/edition-2/extra.html
+++ b/blog/templates/edition-2/extra.html
@@ -17,6 +17,6 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus(search_term=page.title ~ " (Extra Post)") }}
+        {{ snippets::giscus(search_term=page.title ~ " (Extra Post)", translated=false) }}
     </section>
 {% endblock after_main %}

--- a/blog/templates/edition-2/page.html
+++ b/blog/templates/edition-2/page.html
@@ -118,7 +118,12 @@
         {% else %}
             {% set search_term=page.title %}
         {% endif %}
-        {{ snippets::giscus(search_term=search_term) }}
+        {% if page.lang != "en" %}
+            {% set translated = true %}
+        {% else %}
+            {% set translated = false %}
+        {% endif %}
+        {{ snippets::giscus(search_term=search_term, translated=translated) }}
 
         {%- if page.lang != "en" %}
         <p class="{% if page.extra.rtl %}right-to-left{% endif %}">

--- a/blog/templates/news-page.html
+++ b/blog/templates/news-page.html
@@ -17,7 +17,7 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus(search_term=page.title ~ " (News Post)") }}
+        {{ snippets::giscus(search_term=page.title ~ " (News Post)", translated=false) }}
     </section>
 
 {% endblock after_main %}

--- a/blog/templates/snippets.html
+++ b/blog/templates/snippets.html
@@ -10,12 +10,20 @@
 </p>
 {% endmacro support %}
 
-{% macro giscus(search_term) %}
+{% macro giscus(search_term, translated) %}
+    {% if translated %}
+        {% set category = "Post Comments" %}
+        {% set category_path = "post-comments" %}
+    {% else %}
+        {% set category = "Post Comments (translated)" %}
+        {% set category_path = "post-comments-translated" %}
+    {% endif %}
+
     {% if search_term is number %}
         {% set discussion_url = "https://github.com/phil-opp/blog_os/discussions/" ~ search_term %}
     {% else %}
         {% set search_term_encoded = `"` ~ search_term ~ `"` | urlencode %}
-        {% set discussion_url = `https://github.com/phil-opp/blog_os/discussions/categories/post-comments?discussions_q=` ~ search_term_encoded %}
+        {% set discussion_url = `https://github.com/phil-opp/blog_os/discussions/categories/` ~ category_path ~ `?discussions_q=` ~ search_term_encoded %}
     {% endif %}
 
     <p class="comment-note">
@@ -27,7 +35,7 @@
     <script src="https://giscus.app/client.js"
         data-repo="phil-opp/blog_os"
         data-repo-id="MDEwOlJlcG9zaXRvcnkzOTU3NTEwMQ=="
-        data-category="Post Comments"
+        data-category="{{ category }}"
         data-category-id="MDE4OkRpc2N1c3Npb25DYXRlZ29yeTMzMDE4OTg1"
     {% if search_term is number %}
         data-mapping="number"

--- a/blog/templates/status-update-page.html
+++ b/blog/templates/status-update-page.html
@@ -32,7 +32,7 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus(search_term=page.title) }}
+        {{ snippets::giscus(search_term=page.title, translated=false) }}
     </section>
 
 {% endblock after_main %}


### PR DESCRIPTION
Avoids that a search for the post title returns a thread for a translated post.
