### PR TITLE
Remove goatcounter analytics again

### DIFF
--- a/blog/templates/edition-1/base.html
+++ b/blog/templates/edition-1/base.html
@@ -39,8 +39,6 @@
             </small>
         </footer>
     </div>
-
-    <script data-goatcounter="https://phil-opp.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </body>
 
 </html>

--- a/blog/templates/edition-2/base.html
+++ b/blog/templates/edition-2/base.html
@@ -62,8 +62,6 @@
             </small>
         </footer>
     </div>
-
-    <script data-goatcounter="https://phil-opp.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
This commit removes the https://www.goatcounter.com/ script that we were using for basic, privacy-friendly analytics. I don't really need that data, so there is not much value in keeping it.
