### PR TITLE
Translate the giscus comment system

### DIFF
--- a/blog/templates/edition-2/extra.html
+++ b/blog/templates/edition-2/extra.html
@@ -17,6 +17,6 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus(search_term=page.title ~ " (Extra Post)", translated=false) }}
+        {{ snippets::giscus(search_term=page.title ~ " (Extra Post)", lang=page.lang) }}
     </section>
 {% endblock after_main %}

--- a/blog/templates/edition-2/page.html
+++ b/blog/templates/edition-2/page.html
@@ -118,12 +118,7 @@
         {% else %}
             {% set search_term=page.title %}
         {% endif %}
-        {% if page.lang != "en" %}
-            {% set translated = true %}
-        {% else %}
-            {% set translated = false %}
-        {% endif %}
-        {{ snippets::giscus(search_term=search_term, translated=translated) }}
+        {{ snippets::giscus(search_term=search_term, lang=page.lang) }}
 
         {%- if page.lang != "en" %}
         <p class="{% if page.extra.rtl %}right-to-left{% endif %}">

--- a/blog/templates/news-page.html
+++ b/blog/templates/news-page.html
@@ -17,7 +17,7 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus(search_term=page.title ~ " (News Post)", translated=false) }}
+        {{ snippets::giscus(search_term=page.title ~ " (News Post)", lang=page.lang) }}
     </section>
 
 {% endblock after_main %}

--- a/blog/templates/snippets.html
+++ b/blog/templates/snippets.html
@@ -10,8 +10,8 @@
 </p>
 {% endmacro support %}
 
-{% macro giscus(search_term, translated) %}
-    {% if translated %}
+{% macro giscus(search_term, lang) %}
+    {% if lang != "en" %}
         {% set category = "Post Comments (translated)" %}
         {% set category_path = "post-comments-translated" %}
     {% else %}
@@ -46,6 +46,7 @@
         data-reactions-enabled="1"
         data-emit-metadata="1"
         data-theme="preferred_color_scheme"
+        data-lang="{{ lang }}"
         crossorigin="anonymous"
         async>
     </script>

--- a/blog/templates/status-update-page.html
+++ b/blog/templates/status-update-page.html
@@ -32,7 +32,7 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus(search_term=page.title, translated=false) }}
+        {{ snippets::giscus(search_term=page.title, lang=page.lang) }}
     </section>
 
 {% endblock after_main %}


### PR DESCRIPTION
The giscus comment system is already translated to a variety of languages. We just need to set the `data-lang` tag accordingly.