### PR TITLE
CI: Move link check to separate workflow

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -38,20 +38,6 @@ jobs:
         name: generated_site
         path: blog/public
 
-  zola_check:
-    name: "Zola Check"
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: 'Download Zola'
-      run: curl -sL https://github.com/getzola/zola/releases/download/v0.16.1/zola-v0.16.1-x86_64-unknown-linux-gnu.tar.gz | tar zxv
-
-    - name: "Run zola check"
-      run: ../zola check
-      working-directory: "blog"
-
   check_spelling:
     name: "Check Spelling"
     runs-on: ubuntu-latest

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,27 @@
+name: Check Links
+
+on:
+  push:
+    branches:
+      - "*"
+      - "!staging.tmp"
+    tags:
+      - "*"
+  pull_request:
+  schedule:
+    - cron: "0 0 1/4 * *" # every 4 days
+
+jobs:
+  zola_check:
+    name: "Zola Check"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: "Download Zola"
+        run: curl -sL https://github.com/getzola/zola/releases/download/v0.16.1/zola-v0.16.1-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+
+      - name: "Run zola check"
+        run: ../zola check
+        working-directory: "blog"


### PR DESCRIPTION
The job often fails temporarily, which can be confusing to contributors. By moving it to a separate 'Check Links' workflow, it hopefully becomes clearer that the failure is unrelated to a PR.
