### PR TITLE
Fix dead links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   zola_check:
-    name: "Zola Check"
+    name: "Zola Link Check"
     runs-on: ubuntu-latest
 
     steps:

--- a/blog/config.toml
+++ b/blog/config.toml
@@ -14,18 +14,18 @@ smart_punctuation = true
 
 [link_checker]
 skip_prefixes = [
-    "https://crates.io/crates", # see https://github.com/rust-lang/crates.io/issues/788
-    "https://www.amd.com/system/files/TechDocs/", # seems to have problems with PDFs
+    "https://crates.io/crates",                                          # see https://github.com/rust-lang/crates.io/issues/788
+    "https://www.amd.com/system/files/TechDocs/",                        # seems to have problems with PDFs
     "https://developer.apple.com/library/archive/qa/qa1118/_index.html", # results in a 401 (I don't know why)
-    "https://github.com", # rate limiting often leads to "Error 429 Too Many Requests"
-    "https://www.linkedin.com/", # seems to send invalid HTTP status codes
+    "https://github.com",                                                # rate limiting often leads to "Error 429 Too Many Requests"
+    "https://www.linkedin.com/",                                         # seems to send invalid HTTP status codes
 ]
 skip_anchor_prefixes = [
-     "https://github.com/", # see https://github.com/getzola/zola/issues/805
-     "https://docs.rs/x86_64/0.1.2/src/", # source code highlight
-     "https://doc.rust-jp.rs/book-ja/", # seems like Zola has problems with Japanese anchor names
-     "https://doc.rust-jp.rs/edition-guide/rust-2018", # seems like Zola has problems with Japanese anchor names
-     "https://doc.rust-jp.rs/rust-nomicon-ja/", # seems like Zola has problems with Japanese anchor names
+    "https://github.com/",                            # see https://github.com/getzola/zola/issues/805
+    "https://docs.rs/x86_64/0.1.2/src/",              # source code highlight
+    "https://doc.rust-jp.rs/book-ja/",                # seems like Zola has problems with Japanese anchor names
+    "https://doc.rust-jp.rs/edition-guide/rust-2018", # seems like Zola has problems with Japanese anchor names
+    "https://doc.rust-jp.rs/rust-nomicon-ja/",        # seems like Zola has problems with Japanese anchor names
 ]
 
 [extra]

--- a/blog/config.toml
+++ b/blog/config.toml
@@ -24,6 +24,7 @@ skip_anchor_prefixes = [
      "https://github.com/", # see https://github.com/getzola/zola/issues/805
      "https://docs.rs/x86_64/0.1.2/src/", # source code highlight
      "https://doc.rust-jp.rs/book-ja/", # seems like Zola has problems with Japanese anchor names
+     "https://doc.rust-jp.rs/edition-guide/rust-2018", # seems like Zola has problems with Japanese anchor names
 ]
 
 [extra]

--- a/blog/config.toml
+++ b/blog/config.toml
@@ -25,6 +25,7 @@ skip_anchor_prefixes = [
      "https://docs.rs/x86_64/0.1.2/src/", # source code highlight
      "https://doc.rust-jp.rs/book-ja/", # seems like Zola has problems with Japanese anchor names
      "https://doc.rust-jp.rs/edition-guide/rust-2018", # seems like Zola has problems with Japanese anchor names
+     "https://doc.rust-jp.rs/rust-nomicon-ja/", # seems like Zola has problems with Japanese anchor names
 ]
 
 [extra]

--- a/blog/content/edition-1/posts/03-set-up-rust/index.md
+++ b/blog/content/edition-1/posts/03-set-up-rust/index.md
@@ -406,9 +406,7 @@ So the linker can't find a function named `_Unwind_Resume` that is referenced e.
 
 [iterator.rs:389]: https://github.com/rust-lang/rust/blob/c58c928e658d2e45f816fd05796a964aa83759da/src/libcore/iter/iterator.rs#L389
 
-By default, the destructors of all stack variables are run when a `panic` occurs. This is called _unwinding_ and allows parent threads to [recover from panics]. However, it requires a platform specific gcc library, which isn't available in our kernel.
-
-[recover from panics]: https://www.howtobuildsoftware.com/index.php/how-do/fFH/rust-recovering-from-panic-in-another-thread
+By default, the destructors of all stack variables are run when a `panic` occurs. This is called _unwinding_ and allows parent threads to recover from panics. However, it requires a platform specific gcc library, which isn't available in our kernel.
 
 Fortunately, Rust allows us to disable unwinding for our target. For that we add the following line to our `x86_64-blog_os.json` file:
 


### PR DESCRIPTION
- Disable anchor checking for Japanese Rust edition guide
- Remove dead link from first edition
