### PR TITLE
Remove warning output from QEMU command.

### DIFF
--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
@@ -448,7 +448,6 @@ We can now boot the disk image in a virtual machine. To boot it in [QEMU], execu
 
 ```
 > qemu-system-x86_64 -drive format=raw,file=target/x86_64-blog_os/debug/bootimage-blog_os.bin
-warning: TCG doesn't support requested feature: CPUID.01H:ECX.vmx [bit 5]
 ```
 
 This opens a separate window which should look similar to this:


### PR DESCRIPTION
The command to run QEMU produces an output, but the output and
its message is not needed to complete the tutorial.