### PR TITLE
Add `zola` to `blog/.gitignore`

### DIFF
--- a/blog/.gitignore
+++ b/blog/.gitignore
@@ -1,1 +1,2 @@
 /public
+zola


### PR DESCRIPTION
Make git ignore 'zola' when contributors locally
build & test the blog with `./zola serve`.

Meant to be a small usability improvement for contributors.