### PR TITLE
#1063: Begin `0.11` porting process

### DIFF
--- a/blog/content/edition-1/extra/naked-exceptions/01-catching-exceptions/index.md
+++ b/blog/content/edition-1/extra/naked-exceptions/01-catching-exceptions/index.md
@@ -422,7 +422,7 @@ extern "C" fn divide_by_zero_handler() -> ! {
 ```
 We register a single handler function for a [divide by zero error] \(index 0). Like the name says, this exception occurs when dividing a number by 0. Thus we have an easy way to test our new exception handler.
 
-[divide by zero error]: https://wiki.osdev.org/Exceptions#Divide-by-zero_Error
+[divide by zero error]: https://wiki.osdev.org/Exceptions#Division_Error
 
 However, it doesn't work this way:
 

--- a/blog/content/edition-1/posts/10-double-faults/index.md
+++ b/blog/content/edition-1/posts/10-double-faults/index.md
@@ -128,7 +128,7 @@ First Exception | Second Exception
 [Divide-by-zero],<br>[Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault] | [Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault]
 [Page Fault] | [Page Fault],<br>[Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault]
 
-[Divide-by-zero]: https://wiki.osdev.org/Exceptions#Divide-by-zero_Error
+[Divide-by-zero]: https://wiki.osdev.org/Exceptions#Division_Error
 [Invalid TSS]: https://wiki.osdev.org/Exceptions#Invalid_TSS
 [Segment Not Present]: https://wiki.osdev.org/Exceptions#Segment_Not_Present
 [Stack-Segment Fault]: https://wiki.osdev.org/Exceptions#Stack-Segment_Fault

--- a/blog/content/edition-1/posts/10-double-faults/index.md
+++ b/blog/content/edition-1/posts/10-double-faults/index.md
@@ -495,7 +495,7 @@ We define that the 0th IST entry is the double fault stack (any other IST index 
 #### Loading the TSS
 Now that we created a new TSS, we need a way to tell the CPU that it should use it. Unfortunately, this is a bit cumbersome, since the TSS is a Task State _Segment_ (for historical reasons). So instead of loading the table directly, we need to add a new segment descriptor to the [Global Descriptor Table] \(GDT). Then we can load our TSS invoking the [`ltr` instruction] with the respective GDT index.
 
-[Global Descriptor Table]: https://web.archive.org/web/20190217233448/https://www.flingos.co.uk/docs/reference/Global-Descriptor-Table/
+[Global Descriptor Table]:https://wiki.osdev.org/Global_Descriptor_Table
 [`ltr` instruction]: https://www.felixcloutier.com/x86/ltr
 
 ### The Global Descriptor Table (again)

--- a/blog/content/edition-2/posts/04-testing/index.ja.md
+++ b/blog/content/edition-2/posts/04-testing/index.ja.md
@@ -890,7 +890,7 @@ fn test_println() {
 
 標準ライブラリのテストフレームワークは、[`#[should_panic]`属性][should_panic]をサポートしています。これを使うと、失敗しなければならないテストを作ることができます。これは、例えば、関数が無効な引数を渡されたときに失敗することを確かめる場合などに便利です。残念なことに、この機能は標準ライブラリのサポートを必要とするため、`#[no_std]`クレートではこの属性はサポートされていません。
 
-[should_panic]: https://doc.rust-jp.rs/rust-by-example-ja/testing/unit_testing.html#testing-panics
+[should_panic]: https://doc.rust-jp.rs/rust-by-example-ja/testing/unit_testing.html#パニックをテストする
 
 `#[should_panic]`属性は使えませんが、パニックハンドラから成功のエラーコードで終了するような結合テストを作れば、似たような動きをさせることはできます。そのようなテストを`should_panic`という名前で作ってみましょう：
 

--- a/blog/content/edition-2/posts/06-double-faults/index.fa.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.fa.md
@@ -138,7 +138,7 @@ extern "x86-interrupt" fn double_fault_handler(
 [Divide-by-zero],<br>[Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault] | [Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault]
 [Page Fault] | [Page Fault],<br>[Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault]
 
-[Divide-by-zero]: https://wiki.osdev.org/Exceptions#Divide-by-zero_Error
+[Divide-by-zero]: https://wiki.osdev.org/Exceptions#Division_Error
 [Invalid TSS]: https://wiki.osdev.org/Exceptions#Invalid_TSS
 [Segment Not Present]: https://wiki.osdev.org/Exceptions#Segment_Not_Present
 [Stack-Segment Fault]: https://wiki.osdev.org/Exceptions#Stack-Segment_Fault

--- a/blog/content/edition-2/posts/06-double-faults/index.fa.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.fa.md
@@ -286,7 +286,7 @@ lazy_static! {
 
 اکنون که TSS جدیدی ایجاد کردیم، به روشی نیاز داریم که به CPU بگوییم باید از آن استفاده کند. متأسفانه این کمی دشوار است، زیرا TSS به دلایل تاریخی از سیستم سگمنت‌بندی (ترجمه: segmentation) استفاده می‌کند. به جای بارگذاری مستقیم جدول، باید توصیفگر سگمنت جدیدی را به [جدول توصیف‌گر سراسری] \(Global Descriptor Table: GDT) اضافه کنیم. سپس می‌توانیم TSS خود را با فراخوانی [دستور `ltr`] با اندیس GDT مربوطه بارگذاری کنیم. (دلیل این‌که نام ماژول را `gdt` گذاشتیم نیز همین بود).
 
-[جدول توصیف‌گر سراسری]: https://web.archive.org/web/20190217233448/https://www.flingos.co.uk/docs/reference/Global-Descriptor-Table/
+[جدول توصیف‌گر سراسری]:https://wiki.osdev.org/Global_Descriptor_Table
 [دستور `ltr`]: https://www.felixcloutier.com/x86/ltr
 
 ### جدول توصیف‌گر سراسری

--- a/blog/content/edition-2/posts/06-double-faults/index.ja.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.ja.md
@@ -132,7 +132,7 @@ CPUはダブルフォルトハンドラを呼べるようになったので、�
 [ゼロ除算],<br>[無効TSS],<br>[セグメント不在],<br>[スタックセグメントフォルト],<br>[一般保護違反] | [無効TSS],<br>[セグメント不在],<br>[スタックセグメントフォルト],<br>[一般保護違反]
 [ページフォルト] | [ページフォルト],<br>[無効TSS],<br>[セグメント不在],<br>[スタックセグメントフォルト],<br>[一般保護違反]
 
-[ゼロ除算]: https://wiki.osdev.org/Exceptions#Divide-by-zero_Error
+[ゼロ除算]: https://wiki.osdev.org/Exceptions#Division_Error
 [無効TSS]: https://wiki.osdev.org/Exceptions#Invalid_TSS
 [セグメント不在]: https://wiki.osdev.org/Exceptions#Segment_Not_Present
 [スタックセグメントフォルト]: https://wiki.osdev.org/Exceptions#Stack-Segment_Fault

--- a/blog/content/edition-2/posts/06-double-faults/index.ja.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.ja.md
@@ -275,7 +275,7 @@ Rustの定数評価機はこの初期化をコンパイル時に行うことが�
 #### TSSを読み込む
 新しいTSSをつくったので、CPUにそれを使うように教える方法が必要です。残念ながら、これはちょっと面倒くさいです。なぜならTSSは（歴史的な理由で）セグメンテーションシステムを使うためです。テーブルを直接読み込むのではなく、新しいセグメントディスクリプタを[グローバルディスクリプタテーブル]（GDT: Global Descriptor Table）に追加する必要があります。そうすると各自のGDTインデックスで[`ltr`命令]を呼び出すことで私達のTSSを読み込むことができます。
 
-[グローバルディスクリプタテーブル]: https://web.archive.org/web/20190217233448/https://www.flingos.co.uk/docs/reference/Global-Descriptor-Table/
+[グローバルディスクリプタテーブル]:https://wiki.osdev.org/Global_Descriptor_Table
 [`ltr`命令]: https://www.felixcloutier.com/x86/ltr
 
 ### グローバルディスクリプタテーブル

--- a/blog/content/edition-2/posts/06-double-faults/index.ko.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.ko.md
@@ -278,7 +278,7 @@ Rust의 const evaluator가 위와 같은 TSS의 초기화를 컴파일 중에 �
 #### TSS 불러오기
 새로운 TSS도 만들었으니, 이제 CPU에게 이 TSS를 쓰도록 지시할 방법이 필요합니다. TSS가 역사적 이유로 인해 세그멘테이션 (segmentation) 시스템을 사용하는 탓에, CPU에 TSS를 쓰도록 지시하는 과정이 꽤 번거롭습니다. TSS를 직접 불러오는 대신, [전역 서술자 테이블 (Global Descriptor Table; GDT)][Global Descriptor Table]을 가리키는 새로운 세그먼트 서술자 (segment descriptor)를 추가해야 합니다. 그 후 [`ltr` 명령어][`ltr` instruction]에 GDT 안에서의 TSS의 인덱스를 주고 호출하여 TSS를 불러올 수 있습니다. (이것이 모듈 이름을 `gdt`로 설정한 이유입니다.)
 
-[Global Descriptor Table]: https://web.archive.org/web/20190217233448/https://www.flingos.co.uk/docs/reference/Global-Descriptor-Table/
+[Global Descriptor Table]:https://wiki.osdev.org/Global_Descriptor_Table
 [`ltr` instruction]: https://www.felixcloutier.com/x86/ltr
 
 ### 전역 서술자 테이블 (Global Descriptor Table)

--- a/blog/content/edition-2/posts/06-double-faults/index.ko.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.ko.md
@@ -135,7 +135,7 @@ _“예외 처리 함수를 호출하는 것에 실패했을 때”_ 라는 게 
 [Divide-by-zero],<br>[Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault] | [Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault]
 [Page Fault] | [Page Fault],<br>[Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault]
 
-[Divide-by-zero]: https://wiki.osdev.org/Exceptions#Divide-by-zero_Error
+[Divide-by-zero]: https://wiki.osdev.org/Exceptions#Division_Error
 [Invalid TSS]: https://wiki.osdev.org/Exceptions#Invalid_TSS
 [Segment Not Present]: https://wiki.osdev.org/Exceptions#Segment_Not_Present
 [Stack-Segment Fault]: https://wiki.osdev.org/Exceptions#Stack-Segment_Fault

--- a/blog/content/edition-2/posts/06-double-faults/index.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.md
@@ -272,7 +272,7 @@ Note that this double fault stack has no guard page that protects against stack 
 #### Loading the TSS
 Now that we've created a new TSS, we need a way to tell the CPU that it should use it. Unfortunately, this is a bit cumbersome since the TSS uses the segmentation system (for historical reasons). Instead of loading the table directly, we need to add a new segment descriptor to the [Global Descriptor Table] \(GDT). Then we can load our TSS by invoking the [`ltr` instruction] with the respective GDT index. (This is the reason why we named our module `gdt`.)
 
-[Global Descriptor Table]: https://web.archive.org/web/20190217233448/https://www.flingos.co.uk/docs/reference/Global-Descriptor-Table/
+[Global Descriptor Table]:https://wiki.osdev.org/Global_Descriptor_Table
 [`ltr` instruction]: https://www.felixcloutier.com/x86/ltr
 
 ### The Global Descriptor Table

--- a/blog/content/edition-2/posts/06-double-faults/index.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.md
@@ -129,7 +129,7 @@ First Exception | Second Exception
 [Divide-by-zero],<br>[Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault] | [Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault]
 [Page Fault] | [Page Fault],<br>[Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault]
 
-[Divide-by-zero]: https://wiki.osdev.org/Exceptions#Divide-by-zero_Error
+[Divide-by-zero]: https://wiki.osdev.org/Exceptions#Division_Error
 [Invalid TSS]: https://wiki.osdev.org/Exceptions#Invalid_TSS
 [Segment Not Present]: https://wiki.osdev.org/Exceptions#Segment_Not_Present
 [Stack-Segment Fault]: https://wiki.osdev.org/Exceptions#Stack-Segment_Fault

--- a/blog/content/edition-2/posts/06-double-faults/index.zh-CN.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.zh-CN.md
@@ -137,7 +137,7 @@ extern "x86-interrupt" fn double_fault_handler(
 | [Divide-by-zero],<br>[Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault] | [Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault]                  |
 | [Page Fault]                                                                                                          | [Page Fault],<br>[Invalid TSS],<br>[Segment Not Present],<br>[Stack-Segment Fault],<br>[General Protection Fault] |
 
-[Divide-by-zero]: https://wiki.osdev.org/Exceptions#Divide-by-zero_Error
+[Divide-by-zero]: https://wiki.osdev.org/Exceptions#Division_Error
 [Invalid TSS]: https://wiki.osdev.org/Exceptions#Invalid_TSS
 [Segment Not Present]: https://wiki.osdev.org/Exceptions#Segment_Not_Present
 [Stack-Segment Fault]: https://wiki.osdev.org/Exceptions#Stack-Segment_Fault

--- a/blog/content/edition-2/posts/06-double-faults/index.zh-CN.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.zh-CN.md
@@ -282,7 +282,7 @@ lazy_static! {
 #### 加载TSS
 我们已经创建了一个TSS，现在的问题就是怎么让CPU使用它。不幸的是这事有点繁琐，因为TSS用到了分段系统（历史原因）。但我们可以不直接加载，而是在[全局描述符表][Global Descriptor Table]（GDT）中添加一个段描述符，然后我们就可以通过[`ltr` 指令][`ltr` instruction]加上GDT序号加载我们的TSS。（这也是为什么我们将模块取名为 `gdt`。）
 
-[Global Descriptor Table]: https://web.archive.org/web/20190217233448/https://www.flingos.co.uk/docs/reference/Global-Descriptor-Table/
+[Global Descriptor Table]:https://wiki.osdev.org/Global_Descriptor_Table
 [`ltr` instruction]: https://www.felixcloutier.com/x86/ltr
 
 ### 全局描述符表

--- a/blog/content/edition-3/posts/02-booting/index.md
+++ b/blog/content/edition-3/posts/02-booting/index.md
@@ -481,7 +481,7 @@ Now that we've covered how to support BIOS, UEFI, or both, it's time to put ever
 # in boot/Cargo.toml
 
 [dependencies]
-bootloader = 0.11.0
+bootloader = "0.11.0"
 bootloader-x86_64-bios-boot-sector = "0.11.0"
 bootloader-x86_64-bios-common = "0.11.0"
 bootloader-x86_64-bios-stage-2 = "0.11.0"

--- a/blog/content/edition-3/posts/02-booting/index.md
+++ b/blog/content/edition-3/posts/02-booting/index.md
@@ -250,7 +250,7 @@ In this section, we will learn how to combine the [minimal kernel] we created in
 
 Since bootloaders quite complex on their own, we won't create our own bootloader here (but we are planning a separate series of posts on this).
 Instead, we will boot our kernel using the [`bootloader`] crate.
-This crate is subdivided into multiple crates to support both BIOS (via the multitude of `bootloader-x86_64-bios-*` sub-crates) and UEFI (via the `bootloader-x86_64-uefi` sub-crate) booting, provide all the necessary system information we need (via the `bootloader_api` sub-crate), and creates a reasonable default execution environment for our kernel.
+This crate is subdivided into multiple crates to support both BIOS (via the multitude of `bootloader-x86_64-bios-*` sub-crates) and UEFI (via the `bootloader-x86_64-uefi` sub-crate) booting, provide all the necessary system information we need (via the `bootloader_api` sub-crate), and create a reasonable default execution environment for our kernel.
 This way, we can focus on the actual kernel design in the following posts instead of spending a lot of time on system initialization.
 
 In order to use this crate in our kernel, we need to add a dependency on `bootloader_api`:

--- a/blog/content/edition-3/posts/02-booting/index.md
+++ b/blog/content/edition-3/posts/02-booting/index.md
@@ -452,11 +452,11 @@ In order to support BIOS booting, there are 5 additional dependencies that your 
 # in boot/Cargo.toml
 
 [dependencies]
-bootloader-x86_64-bios-boot-sector = 0.11.0
-bootloader-x86_64-bios-common = 0.11.0
-bootloader-x86_64-bios-stage-2 = 0.11.0
-bootloader-x86_64-bios-stage-3 = 0.11.0
-bootloader-x86_64-bios-stage-4 = 0.11.0
+bootloader-x86_64-bios-boot-sector = "0.11.0"
+bootloader-x86_64-bios-common = "0.11.0"
+bootloader-x86_64-bios-stage-2 = "0.11.0"
+bootloader-x86_64-bios-stage-3 = "0.11.0"
+bootloader-x86_64-bios-stage-4 = "0.11.0"
 ```
 
 Each of these stages represents an important part of the boot process. The boot sector, as you'd probably guess, is where the BIOS looks on the disk to find bootable code; without it the BIOS won't know an OS exists on the disk. The `-common` crate contains all the APIs that all subsequent stages depend on. Stage 2 is what switches you to protected mode; without it, you're stuck in 16-bit emulation. Stage 3 defines the jump to long mode, and finally Stage 4 maps memory so the kernel can allocate a heap later on.
@@ -468,7 +468,7 @@ Unlike BIOS, UEFI booting only has one additional dependency:
 # in boot/Cargo.toml
 
 [dependencies]
-bootloader-x86_64-uefi = 0.11.0
+bootloader-x86_64-uefi = "0.11.0"
 ```
 
 This is because UEFI supports booting directly into long mode. This completely eliminates the need for a real-to-protected-to-long-mode trampoline, and it supports this by default if the bootloader is run as a UEFI application — which it is in the case of the `bootloader` crate. However, QEMU needs additional setup to support emulating UEFI, as we will explain below, so until we go over that, you'll need to use real UEFI hardware to test this.
@@ -482,12 +482,12 @@ Now that we've covered how to support BIOS, UEFI, or both, it's time to put ever
 
 [dependencies]
 bootloader = 0.11.0
-bootloader-x86_64-bios-boot-sector = 0.11.0
-bootloader-x86_64-bios-common = 0.11.0
-bootloader-x86_64-bios-stage-2 = 0.11.0
-bootloader-x86_64-bios-stage-3 = 0.11.0
-bootloader-x86_64-bios-stage-4 = 0.11.0
-bootloader-x86_64-uefi = 0.11.0
+bootloader-x86_64-bios-boot-sector = "0.11.0"
+bootloader-x86_64-bios-common = "0.11.0"
+bootloader-x86_64-bios-stage-2 = "0.11.0"
+bootloader-x86_64-bios-stage-3 = "0.11.0"
+bootloader-x86_64-bios-stage-4 = "0.11.0"
+bootloader-x86_64-uefi = "0.11.0"
 ```
 
 Once all dependencies are accounted for, it's time to put everything together:


### PR DESCRIPTION
Version 0.11 of the bootloader crate introduces a lot of breaking changes, so time to start work on making sure that all posts are up-to-date to (hopefully) make it far easier for Phil to move forward with fixing #1063.