### PR TITLE
Ammend small typo: Change from set_cs to set_reg

### DIFF
--- a/blog/content/edition-2/posts/06-double-faults/index.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.md
@@ -374,7 +374,7 @@ pub fn init() {
 }
 ```
 
-We reload the code segment register using [`set_cs`] and load the TSS using [`load_tss`]. The functions are marked as `unsafe`, so we need an `unsafe` block to invoke them. The reason is that it might be possible to break memory safety by loading invalid selectors.
+We reload the code segment register using [`set_reg`] and load the TSS using [`load_tss`]. The functions are marked as `unsafe`, so we need an `unsafe` block to invoke them. The reason is that it might be possible to break memory safety by loading invalid selectors.
 
 [`set_cs`]: https://docs.rs/x86_64/0.14.2/x86_64/instructions/segmentation/fn.set_cs.html
 [`load_tss`]: https://docs.rs/x86_64/0.14.2/x86_64/instructions/tables/fn.load_tss.html


### PR DESCRIPTION
`set_cs` is deprecated according to: https://docs.rs/x86_64/latest/x86_64/instructions/segmentation/fn.set_cs.html

Also in the post the displayed code uses `x86_64::instructions::segmentation::CS::set_reg` instead of `x86_64::instructions::segmentation::set_cs`