### PR TITLE
Update `zola` to `v0.17.2`

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: 'Download Zola'
-      run: curl -sL https://github.com/getzola/zola/releases/download/v0.16.1/zola-v0.16.1-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+      run: curl -sL https://github.com/getzola/zola/releases/download/v0.17.2/zola-v0.17.2-x86_64-unknown-linux-gnu.tar.gz | tar zxv
     - name: 'Install Python Libraries'
       run: python -m pip install --user -r requirements.txt
       working-directory: "blog"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: "Download Zola"
-        run: curl -sL https://github.com/getzola/zola/releases/download/v0.16.1/zola-v0.16.1-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+        run: curl -sL https://github.com/getzola/zola/releases/download/v0.17.2/zola-v0.17.2-x86_64-unknown-linux-gnu.tar.gz | tar zxv
 
       - name: "Run zola check"
         run: ../zola check

--- a/blog/config.toml
+++ b/blog/config.toml
@@ -1,4 +1,6 @@
 base_url = "https://os.phil-opp.com"
+title = "Writing an OS in Rust"
+description = "This blog series creates a small operating system in the Rust programming language. Each post is a small tutorial and includes all needed code."
 
 generate_feed = true
 feed_filename = "rss.xml"
@@ -34,10 +36,7 @@ author = { name = "Philipp Oppermann" }
 default_language = "en"
 languages = ["en", "zh-CN", "zh-TW", "fr", "ja", "fa", "ru", "ko"]
 
-[languages.en]
-title = "Writing an OS in Rust"
-description = "This blog series creates a small operating system in the Rust programming language. Each post is a small tutorial and includes all needed code."
-[languages.en.translations]
+[translations]
 lang_name = "English (original)"
 toc = "Table of Contents"
 all_posts = "« All Posts"
@@ -52,9 +51,6 @@ translation_contributors = "With contributions from"
 word_separator = "and"
 
 # Chinese (simplified)
-[languages.zh-CN]
-title = "Writing an OS in Rust"
-description = "This blog series creates a small operating system in the Rust programming language. Each post is a small tutorial and includes all needed code."
 [languages.zh-CN.translations]
 lang_name = "Chinese (simplified)"
 toc = "目录"
@@ -70,9 +66,6 @@ translation_contributors = "With contributions from"
 word_separator = "和"
 
 # Chinese (traditional)
-[languages.zh-TW]
-title = "Writing an OS in Rust"
-description = "This blog series creates a small operating system in the Rust programming language. Each post is a small tutorial and includes all needed code."
 [languages.zh-TW.translations]
 lang_name = "Chinese (traditional)"
 toc = "目錄"
@@ -88,9 +81,6 @@ translation_contributors = "With contributions from"
 word_separator = "和"
 
 # Japanese
-[languages.ja]
-title = "Writing an OS in Rust"
-description = "This blog series creates a small operating system in the Rust programming language. Each post is a small tutorial and includes all needed code."
 [languages.ja.translations]
 lang_name = "Japanese"
 toc = "目次"
@@ -106,9 +96,6 @@ translation_contributors = "With contributions from"
 word_separator = "及び"
 
 # Persian
-[languages.fa]
-title = "Writing an OS in Rust"
-description = "This blog series creates a small operating system in the Rust programming language. Each post is a small tutorial and includes all needed code."
 [languages.fa.translations]
 lang_name = "Persian"
 toc = "فهرست مطالب"
@@ -124,9 +111,6 @@ translation_contributors = "With contributions from"
 word_separator = "و"
 
 # Russian
-[languages.ru]
-title = "Writing an OS in Rust"
-description = "This blog series creates a small operating system in the Rust programming language. Each post is a small tutorial and includes all needed code."
 [languages.ru.translations]
 lang_name = "Russian"
 toc = "Содержание"
@@ -142,9 +126,6 @@ translation_contributors = "With contributions from"
 word_separator = "и"
 
 # French
-[languages.fr]
-title = "Writing an OS in Rust"
-description = "This blog series creates a small operating system in the Rust programming language. Each post is a small tutorial and includes all needed code."
 [languages.fr.translations]
 lang_name = "French"
 toc = "Table des matières"
@@ -160,9 +141,6 @@ translation_contributors = "With contributions from"
 word_separator = "et"
 
 # Korean
-[languages.ko]
-title = "Writing an OS in Rust"
-description = "This blog series creates a small operating system in the Rust programming language. Each post is a small tutorial and includes all needed code."
 [languages.ko.translations]
 lang_name = "Korean"
 toc = "목차"


### PR DESCRIPTION
Updates the blog to the latest version of the [`zola`](https://www.getzola.org/) static site generator.

Changes since the previous version (0.16.1):

## 0.17.2 (2023-03-19)

- Fix one more invalid error with colocated directories
- Revert "Recognize links starting with `www` as external for the link checker" as they won't be external links in practice
- Use page.summary for atom.xml if available
- Fix cachebusting not working with binary files
- Fix warning message for multilingual sites

## 0.17.1 (2023-02-24)

- Fix bugs with colocated directories in the root `content` directory
- Fix `zola serve` not  respecting `preserve_dotfiles_in_output`
- Add `generate_feed` field to the `section` object in templates

## 0.17.0 (2023-02-16)

### Breaking
- `get_file_hash` is removed, use `get_hash` instead. Arguments do not change
- Replace libsass by a Rust implementation: [grass](https://github.com/connorskees/grass). See https://sass-lang.com/documentation/breaking-changes
for breaking changes with libsass: look for "beginning in Dart Sass"
- Merge settings for the default language set in the root of `config.toml` and in the `[languages.{default_lang}]` section. 
This will error if the same keys are defined multiple times
- Code blocks content are no longer included in the search index
- Remove built-ins shortcodes
- Having a file called `index.md` in a folder with a `_index.md` is now an error
- Ignore temp files from vim/emacs/macos/etc as well as files without extensions when getting colocated assets
- Now integrates the file stem of the original file into the processed images filename: {stem}.{hash}.{extension}

### Other

- Add `get_taxonomy_term` function
- Add `slugify.paths_keep_dates` option
- Add command to generate shell completions
- Fix link generation to co-located assets other than images
- Add `get_hash` Tera function
- Minify CSS and JS embedded in HTML
- Fix slow image processing
- Fix `current_url` in taxonomy term
- Add new flag `zola serve --no_port_append` to give the ability to remove port from base url
- `config.markdown` is now available in templates
- Add `preserve_dotfiles_in_output` option in the config
- Add Elasticlunr JSON output for the search index
- Add sorting by slug for pages
- Enable locale date formatting for the Tera `date` filter
- Cachebust fingerprint is now only 20 chars long
- Add `text` alias for plain text highlighting (before, only `txt` was used)
- Adds a new field to `page`: `colocated_path` that points to the folder of the current file being rendered if it's a colocated folder. None otherwise.
- Add `author` as a first-class property to the config and `authors` to pages
- Allows using external URL for `redirect_to`
- Recognize links starting with `www` as external for the link checker