### PR TITLE
Fix panics caused by misaligned pointer dereferences in "Double Faults" & "Introduction to Paging"

### DIFF
--- a/blog/content/edition-2/posts/06-double-faults/index.fa.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.fa.md
@@ -49,7 +49,7 @@ pub extern "C" fn _start() -> ! {
 
     // trigger a page fault
     unsafe {
-        *(0xdeadbeef as *mut u64) = 42;
+        *(0xdeadbeef as *mut u8) = 42;
     };
 
     // as before

--- a/blog/content/edition-2/posts/06-double-faults/index.ja.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.ja.md
@@ -45,7 +45,7 @@ pub extern "C" fn _start() -> ! {
 
     // ページフォルトを起こす
     unsafe {
-        *(0xdeadbeef as *mut u64) = 42;
+        *(0xdeadbeef as *mut u8) = 42;
     };
 
     // 前回同様

--- a/blog/content/edition-2/posts/06-double-faults/index.ko.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.ko.md
@@ -48,7 +48,7 @@ pub extern "C" fn _start() -> ! {
 
     // 페이지 폴트 일으키기
     unsafe {
-        *(0xdeadbeef as *mut u64) = 42;
+        *(0xdeadbeef as *mut u8) = 42;
     };
 
     // 이전과 동일

--- a/blog/content/edition-2/posts/06-double-faults/index.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.md
@@ -42,7 +42,7 @@ pub extern "C" fn _start() -> ! {
 
     // trigger a page fault
     unsafe {
-        *(0xdeadbeef as *mut u64) = 42;
+        *(0xdeadbeef as *mut u8) = 42;
     };
 
     // as before

--- a/blog/content/edition-2/posts/06-double-faults/index.zh-CN.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.zh-CN.md
@@ -47,7 +47,7 @@ pub extern "C" fn _start() -> ! {
 
     // trigger a page fault
     unsafe {
-        *(0xdeadbeef as *mut u64) = 42;
+        *(0xdeadbeef as *mut u8) = 42;
     };
 
     // as before

--- a/blog/content/edition-2/posts/08-paging-introduction/index.fa.md
+++ b/blog/content/edition-2/posts/08-paging-introduction/index.fa.md
@@ -322,7 +322,7 @@ pub extern "C" fn _start() -> ! {
     blog_os::init();
 
     // new
-    let ptr = 0xdeadbeaf as *mut u32;
+    let ptr = 0xdeadbeaf as *mut u8;
     unsafe { *ptr = 42; }
 
     // as before
@@ -347,7 +347,7 @@ pub extern "C" fn _start() -> ! {
 ```rust
 // Note: The actual address might be different for you. Use the address that
 // your page fault handler reports.
-let ptr = 0x2031b2 as *mut u32;
+let ptr = 0x2031b2 as *mut u8;
 
 // read from a code page
 unsafe { let x = *ptr; }

--- a/blog/content/edition-2/posts/08-paging-introduction/index.ja.md
+++ b/blog/content/edition-2/posts/08-paging-introduction/index.ja.md
@@ -329,7 +329,7 @@ pub extern "C" fn _start() -> ! {
     blog_os::init();
 
     // ここを追加
-    let ptr = 0xdeadbeaf as *mut u32;
+    let ptr = 0xdeadbeaf as *mut u8;
     unsafe { *ptr = 42; }
 
     // ここはこれまでと同じ
@@ -354,7 +354,7 @@ pub extern "C" fn _start() -> ! {
 ```rust
 // 注意：実際のアドレスは個々人で違うかもしれません。
 // あなたのページフォルトハンドラが報告した値を使ってください。
-let ptr = 0x2031b2 as *mut u32;
+let ptr = 0x2031b2 as *mut u8;
 
 // コードページから読み込む
 unsafe { let x = *ptr; }

--- a/blog/content/edition-2/posts/08-paging-introduction/index.md
+++ b/blog/content/edition-2/posts/08-paging-introduction/index.md
@@ -316,7 +316,7 @@ pub extern "C" fn _start() -> ! {
     blog_os::init();
 
     // new
-    let ptr = 0xdeadbeaf as *mut u32;
+    let ptr = 0xdeadbeaf as *mut u8;
     unsafe { *ptr = 42; }
 
     // as before
@@ -341,7 +341,7 @@ We see that the current instruction pointer is `0x2031b2`, so we know that this 
 ```rust
 // Note: The actual address might be different for you. Use the address that
 // your page fault handler reports.
-let ptr = 0x2031b2 as *mut u32;
+let ptr = 0x2031b2 as *mut u8;
 
 // read from a code page
 unsafe { let x = *ptr; }

--- a/blog/content/edition-2/posts/08-paging-introduction/index.zh-CN.md
+++ b/blog/content/edition-2/posts/08-paging-introduction/index.zh-CN.md
@@ -325,7 +325,7 @@ pub extern "C" fn _start() -> ! {
     blog_os::init();
 
     // new
-    let ptr = 0xdeadbeaf as *mut u32;
+    let ptr = 0xdeadbeaf as *mut u8;
     unsafe { *ptr = 42; }
 
     // as before
@@ -350,7 +350,7 @@ pub extern "C" fn _start() -> ! {
 ```rust
 // Note: The actual address might be different for you. Use the address that
 // your page fault handler reports.
-let ptr = 0x2031b2 as *mut u32;
+let ptr = 0x2031b2 as *mut u8;
 
 // read from a code page
 unsafe { let x = *ptr; }


### PR DESCRIPTION
**EDIT 2023-05-31:**

I just noticed that post 8 is affected by this as well (as already discussed in #1215) and applied the same fix there.

___

In the "Double Faults" post, the following code is given as an example:
```Rust
// trigger a page fault
unsafe {
    *(0xdeadbeef as *mut u64) = 42;
};
```

Dereferencing `0xdeadbeef` as any type larger than `u8` is [undefined behavior](https://doc.rust-lang.org/reference/behavior-considered-undefined.html), and [a recently merged PR for Rust](https://github.com/rust-lang/rust/pull/98112) added runtime debug assertions for this.

Thus, instead of the desired effects, the above code panics with the message `'misaligned pointer dereference: address must be a multiple of 0x8 but is 0xdeadbeef'`.

Fortunately, the author chose the value `42` such that it fits in an `u8`, facilitating an easy fix without the need to invent another funny address that would additionally be 8-byte aligned ;)

The English blog text does not mention the type of the pointer so I assume that neither do the translations.