### PR TITLE
Fix: Use correct category ID for comment threads of translated posts

### DIFF
--- a/blog/templates/snippets.html
+++ b/blog/templates/snippets.html
@@ -13,9 +13,11 @@
 {% macro giscus(search_term, lang) %}
     {% if lang != "en" %}
         {% set category = "Post Comments (translated)" %}
+        {% set category_id = "DIC_kwDOAlvePc4CPg4c" %}
         {% set category_path = "post-comments-translated" %}
     {% else %}
         {% set category = "Post Comments" %}
+        {% set category_id = "MDE4OkRpc2N1c3Npb25DYXRlZ29yeTMzMDE4OTg1" %}
         {% set category_path = "post-comments" %}
     {% endif %}
 
@@ -36,7 +38,7 @@
         data-repo="phil-opp/blog_os"
         data-repo-id="MDEwOlJlcG9zaXRvcnkzOTU3NTEwMQ=="
         data-category="{{ category }}"
-        data-category-id="MDE4OkRpc2N1c3Npb25DYXRlZ29yeTMzMDE4OTg1"
+        data-category-id="{{ category_id }}"
     {% if search_term is number %}
         data-mapping="number"
     {% else %}


### PR DESCRIPTION
The category ID is used for creating new discussion threads if required. We forgot to adjust it for translated posts, so they ended up in the wrong category. This in turn caused issues such as https://github.com/phil-opp/blog_os/discussions/1214#discussioncomment-5953024.