### PR TITLE
Update post 2 with beginner friendly cargo tips

### DIFF
--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
@@ -260,10 +260,10 @@ That's where the [`build-std` feature] of cargo comes in. It allows to recompile
 [`build-std` feature]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std
 [nightly Rust compilers]: #installing-rust-nightly
 
-To use the feature, we need to create a local [cargo configuration] file at `blog_os/.cargo/config.toml` with the following content:
+To use the feature, we need to create a local [cargo configuration] file at `.cargo/config.toml` (if your cargo project is named `blog_os`, then create the file locally at `blog_os/.cargo/config.toml`) with the following content:
 
 ```toml
-# in blog_os/.cargo/config.toml
+# in .cargo/config.toml
 
 [unstable]
 build-std = ["core", "compiler_builtins"]

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
@@ -260,7 +260,7 @@ That's where the [`build-std` feature] of cargo comes in. It allows to recompile
 [`build-std` feature]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std
 [nightly Rust compilers]: #installing-rust-nightly
 
-To use the feature, we need to create a local [cargo configuration] file at `.cargo/config.toml` (if your cargo project is named `blog_os`, then create the file locally at `blog_os/.cargo/config.toml`) with the following content:
+To use the feature, we need to create a local [cargo configuration] file at `.cargo/config.toml` (the `.cargo` folder should be next to your `src` folder) with the following content:
 
 ```toml
 # in .cargo/config.toml

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
@@ -260,10 +260,10 @@ That's where the [`build-std` feature] of cargo comes in. It allows to recompile
 [`build-std` feature]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std
 [nightly Rust compilers]: #installing-rust-nightly
 
-To use the feature, we need to create a [cargo configuration] file at `.cargo/config.toml` with the following content:
+To use the feature, we need to create a local [cargo configuration] file at `blog_os/.cargo/config.toml` with the following content:
 
 ```toml
-# in .cargo/config.toml
+# in blog_os/.cargo/config.toml
 
 [unstable]
 build-std = ["core", "compiler_builtins"]
@@ -410,7 +410,7 @@ Adding the bootloader as a dependency is not enough to actually create a bootabl
 
 [post-build scripts]: https://github.com/rust-lang/cargo/issues/545
 
-To solve this problem, we created a tool named `bootimage` that first compiles the kernel and bootloader, and then links them together to create a bootable disk image. To install the tool, execute the following command in your terminal:
+To solve this problem, we created a tool named `bootimage` that first compiles the kernel and bootloader, and then links them together to create a bootable disk image. To install the tool, go into your home directory (or any directory outside of your cargo project) and execute the following command in your terminal:
 
 ```
 cargo install bootimage
@@ -418,7 +418,7 @@ cargo install bootimage
 
 For running `bootimage` and building the bootloader, you need to have the `llvm-tools-preview` rustup component installed. You can do so by executing `rustup component add llvm-tools-preview`.
 
-After installing `bootimage` and adding the `llvm-tools-preview` component, we can create a bootable disk image by executing:
+After installing `bootimage` and adding the `llvm-tools-preview` component, we can create a bootable disk image by going back into your cargo project directory and executing:
 
 ```
 > cargo bootimage


### PR DESCRIPTION
As a relatively new person to Rust, I confused the `.cargo/config.toml` with the global cargo config in my home directory (`~/.cargo/config.toml). While this is pretty obviously wrong in hindsight, since I've never used the `[unstable]` options before, I didn't realize my mistake until this next thing that tripped me up.

For `cargo install bootimage`, I think it is reasonable to tell the reader to go into a different directory to execute the command, since it might be the case that the reader has never dealt with different targets before and would have no idea that running `cargo install` for the new target that they just made in a json would be wrong (at least this was me).

This could be worded differently than the changes I made, but I think that the addition of these could only benefit a confused reader.

I'm new to PRs in general so apologies if I messed up something with the branches!