### PR TITLE
Add `in:title` qualifier for discussion links

### DIFF
--- a/blog/templates/snippets.html
+++ b/blog/templates/snippets.html
@@ -24,7 +24,7 @@
     {% if search_term is number %}
         {% set discussion_url = "https://github.com/phil-opp/blog_os/discussions/" ~ search_term %}
     {% else %}
-        {% set search_term_encoded = `"` ~ search_term ~ `"` | urlencode %}
+        {% set search_term_encoded = `"` ~ search_term ~ `"` ~ ` in:title` | urlencode %}
         {% set discussion_url = `https://github.com/phil-opp/blog_os/discussions/categories/` ~ category_path ~ `?discussions_q=` ~ search_term_encoded %}
     {% endif %}
 


### PR DESCRIPTION
Reduces the number of false positives in search.

Reported in https://github.com/phil-opp/blog_os/discussions/999#discussioncomment-4086576