### PR TITLE
Add `.html` alias to 'Set Up GDB' post

### DIFF
--- a/blog/content/edition-1/extra/set-up-gdb/index.md
+++ b/blog/content/edition-1/extra/set-up-gdb/index.md
@@ -2,6 +2,7 @@
 title = "Set Up GDB"
 template = "plain.html"
 path = "set-up-gdb"
+aliases = ["set-up-gdb.html"]
 weight = 4
 +++
 


### PR DESCRIPTION
Some websites still link to the old `.html` URL.

Fixes #1305 