### PR TITLE
Add a note that only `bootloader v0.9` is compatible

### DIFF
--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
@@ -406,6 +406,8 @@ Instead of writing our own bootloader, which is a project on its own, we use the
 bootloader = "0.9"
 ```
 
+**Note:** This post is only compatible with `bootloader v0.9`. Newer versions use a different build system and will result in build errors when following this post.
+
 Adding the bootloader as a dependency is not enough to actually create a bootable disk image. The problem is that we need to link our kernel with the bootloader after compilation, but cargo has no support for [post-build scripts].
 
 [post-build scripts]: https://github.com/rust-lang/cargo/issues/545


### PR DESCRIPTION
Newer versions use a different build system and will result in build errors when following the post.