### PR TITLE
04-testing: Added panic-abort-tests flag note to "duplicate lang item" workaround

### DIFF
--- a/blog/content/edition-2/posts/04-testing/index.md
+++ b/blog/content/edition-2/posts/04-testing/index.md
@@ -91,7 +91,7 @@ When we run `cargo test` now, we see that it now succeeds (if it doesn't, see th
 
 <div class = "warning">
 
-**Note:** There is currently a bug in cargo that leads to "duplicate lang item" errors on `cargo test` in some cases. It occurs when you have set `panic = "abort"` for a profile in your `Cargo.toml`. Try removing it, then `cargo test` should work. See the [cargo issue](https://github.com/rust-lang/cargo/issues/7359) for more information on this.
+**Note:** There is currently a bug in cargo that leads to "duplicate lang item" errors on `cargo test` in some cases. It occurs when you have set `panic = "abort"` for a profile in your `Cargo.toml`. Try removing it, then `cargo test` should work. Alternatively, if that doesn't work, then add `panic-abort-tests = true` to the `[unstable]` section of your `.config/cargo.toml` file. See the [cargo issue](https://github.com/rust-lang/cargo/issues/7359) for more information on this.
 
 </div>
 


### PR DESCRIPTION
`panic-abort-tests = true` will, as described by the [cargo unstable features docs](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#panic-abort-tests), enable nightly support to compile test harness crates with `-Cpanic=abort`. Without this flag Cargo will compile tests, and everything they depend on, with `-Cpanic=unwind` because it’s the only way test-the-crate knows how to operate.

This fixed my compilation issues that were not solved by the other suggested workaround.