### PR TITLE
add return type on `_start()` in code block

### DIFF
--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.md
@@ -656,7 +656,7 @@ Now we can use `println` in our `_start` function:
 // in src/main.rs
 
 #[no_mangle]
-pub extern "C" fn _start() {
+pub extern "C" fn _start() -> ! {
     println!("Hello World{}", "!");
 
     loop {}


### PR DESCRIPTION
Tiny PR adding return type `!` to `_start()` under the "Hello World using println" section, to make it consistent with the other two times `_start()` appears in the blog post.