### PR TITLE
Correcting many_boxes_long_lived test that incorrectly passes for BumpAllocator when run with cargo test -r

### DIFF
--- a/tests/heap_allocation.rs
+++ b/tests/heap_allocation.rs
@@ -7,6 +7,7 @@
 extern crate alloc;
 
 use alloc::{boxed::Box, vec::Vec};
+use core::hint::black_box;
 use blog_os::allocator::HEAP_SIZE;
 use bootloader::{entry_point, BootInfo};
 use core::panic::PanicInfo;
@@ -61,6 +62,7 @@ fn many_boxes_long_lived() {
         let x = Box::new(i);
         assert_eq!(*x, i);
     }
+    black_box(&long_lived); // new - ensures long_lived isn't optimized away
     assert_eq!(*long_lived, 1); // new
 }
 


### PR DESCRIPTION
`BumpAllocator` currently passes `many_boxes_long_lived` in release mode due to `long_lived` and the `assert_eq` being optimised away. Testing in release mode can be useful as it can make tests run faster overall, despite the longer compile time per test and ensures correct functionality when debug code isn't included.