### PR TITLE
Add `rustc-abi` field to target spec JSON

### DIFF
--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.fa.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.fa.md
@@ -197,6 +197,12 @@ rtl = true
 
 For more information, see our post on [disabling SIMD](@/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.md).
 
+```json
+"rustc-abi": "x86-softfloat"
+```
+
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+
 #### کنار هم قرار دادن
 فایل مشخصات هدف ما اکنون به این شکل است:
 
@@ -214,7 +220,8 @@ For more information, see our post on [disabling SIMD](@/edition-2/posts/02-mini
     "linker": "rust-lld",
     "panic-strategy": "abort",
     "disable-redzone": true,
-    "features": "-mmx,-sse,+soft-float"
+    "features": "-mmx,-sse,+soft-float",
+    "rustc-abi": "x86-softfloat"
 }
 ```
 

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.fr.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.fr.md
@@ -194,6 +194,12 @@ Un problème avec la désactivation de SIMD est que les opérations sur les nomb
 
 Pour plus d'informations, voir notre article sur la [désactivation de SIMD](@/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.md).
 
+```json
+"rustc-abi": "x86-softfloat"
+```
+
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+
 #### Assembler le tout
 Notre fichier de spécification de cible ressemble maintenant à ceci :
 
@@ -211,7 +217,8 @@ Notre fichier de spécification de cible ressemble maintenant à ceci :
     "linker": "rust-lld",
     "panic-strategy": "abort",
     "disable-redzone": true,
-    "features": "-mmx,-sse,+soft-float"
+    "features": "-mmx,-sse,+soft-float",
+    "rustc-abi": "x86-softfloat"
 }
 ```
 

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ja.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ja.md
@@ -191,6 +191,13 @@ SIMDを無効化することによる問題に、`x86_64`における浮動小�
 
 より詳しくは、[SIMDを無効化する](@/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.md)ことに関する私達の記事を読んでください。
 
+```json
+"rustc-abi": "x86-softfloat"
+```
+
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+
+
 #### まとめると
 私達のターゲット仕様ファイルは今このようになっているはずです。
 
@@ -208,7 +215,8 @@ SIMDを無効化することによる問題に、`x86_64`における浮動小�
     "linker": "rust-lld",
     "panic-strategy": "abort",
     "disable-redzone": true,
-    "features": "-mmx,-sse,+soft-float"
+    "features": "-mmx,-sse,+soft-float",
+    "rustc-abi": "x86-softfloat"
 }
 ```
 

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ko.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ko.md
@@ -202,6 +202,12 @@ SIMD 레지스터 값들을 메모리에 백업하고 또 다시 복구하는 �
 
 더 자세히 알고 싶으시다면, 저희가 작성한 [SIMD 기능 해제](@/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.ko.md)에 관한 포스트를 확인해주세요.
 
+```json
+"rustc-abi": "x86-softfloat"
+```
+
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+
 #### 요약
 컴파일 대상 환경 설정 파일을 아래와 같이 작성합니다:
 
@@ -219,7 +225,8 @@ SIMD 레지스터 값들을 메모리에 백업하고 또 다시 복구하는 �
     "linker": "rust-lld",
     "panic-strategy": "abort",
     "disable-redzone": true,
-    "features": "-mmx,-sse,+soft-float"
+    "features": "-mmx,-sse,+soft-float",
+    "rustc-abi": "x86-softfloat"
 }
 ```
 

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
@@ -189,6 +189,12 @@ A problem with disabling SIMD is that floating point operations on `x86_64` requ
 
 For more information, see our post on [disabling SIMD](@/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.md).
 
+```json
+"rustc-abi": "x86-softfloat"
+```
+
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+
 #### Putting it Together
 Our target specification file now looks like this:
 
@@ -206,7 +212,8 @@ Our target specification file now looks like this:
     "linker": "rust-lld",
     "panic-strategy": "abort",
     "disable-redzone": true,
-    "features": "-mmx,-sse,+soft-float"
+    "features": "-mmx,-sse,+soft-float",
+    "rustc-abi": "x86-softfloat"
 }
 ```
 

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ru.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ru.md
@@ -194,6 +194,12 @@ Cargo поддерживает различные целевые системы 
 
 Для получения дополнительной информации см. наш пост об [отключении SIMD](@/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.ru.md).
 
+```json
+"rustc-abi": "x86-softfloat"
+```
+
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+
 #### Соединяем все вместе
 
 Наша спецификация целовой платформы выглядит следующим образом:
@@ -212,7 +218,8 @@ Cargo поддерживает различные целевые системы 
   "linker": "rust-lld",
   "panic-strategy": "abort",
   "disable-redzone": true,
-  "features": "-mmx,-sse,+soft-float"
+  "features": "-mmx,-sse,+soft-float",
+  "rustc-abi": "x86-softfloat"
 }
 ```
 

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.zh-CN.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.zh-CN.md
@@ -161,6 +161,12 @@ Nightly 版本的编译器允许我们在源码的开头插入**特性标签**�
 
 [disabling SIMD]: @/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.zh-CN.md
 
+```json
+"rustc-abi": "x86-softfloat"
+```
+
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+
 现在，我们将各个配置项整合在一起。我们的目标配置清单应该长这样：
 
 ```json
@@ -177,7 +183,8 @@ Nightly 版本的编译器允许我们在源码的开头插入**特性标签**�
     "linker": "rust-lld",
     "panic-strategy": "abort",
     "disable-redzone": true,
-    "features": "-mmx,-sse,+soft-float"
+    "features": "-mmx,-sse,+soft-float",
+    "rustc-abi": "x86-softfloat"
 }
 ```
 


### PR DESCRIPTION
The Rust compiler now requires an explicit `rustc-abi: x86-softfloat` field when using the soft-float target feature. This was added in https://github.com/rust-lang/rust/pull/136146 and is part of the latest nightlies.

I updated the post branches in commit 688a21e4
