### PR TITLE
Fix typo when referencing the `rustc-abi` field.

### DIFF
--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.fa.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.fa.md
@@ -201,7 +201,7 @@ For more information, see our post on [disabling SIMD](@/edition-2/posts/02-mini
 "rustc-abi": "x86-softfloat"
 ```
 
-As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `rustc-abi` field to `x86-softfloat`.
 
 #### کنار هم قرار دادن
 فایل مشخصات هدف ما اکنون به این شکل است:

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.fr.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.fr.md
@@ -198,7 +198,7 @@ Pour plus d'informations, voir notre article sur la [désactivation de SIMD](@/e
 "rustc-abi": "x86-softfloat"
 ```
 
-As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `rustc-abi` field to `x86-softfloat`.
 
 #### Assembler le tout
 Notre fichier de spécification de cible ressemble maintenant à ceci :

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ja.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ja.md
@@ -195,7 +195,7 @@ SIMDを無効化することによる問題に、`x86_64`における浮動小�
 "rustc-abi": "x86-softfloat"
 ```
 
-As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `rustc-abi` field to `x86-softfloat`.
 
 
 #### まとめると

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ko.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ko.md
@@ -206,7 +206,7 @@ SIMD 레지스터 값들을 메모리에 백업하고 또 다시 복구하는 �
 "rustc-abi": "x86-softfloat"
 ```
 
-As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `rustc-abi` field to `x86-softfloat`.
 
 #### 요약
 컴파일 대상 환경 설정 파일을 아래와 같이 작성합니다:

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
@@ -193,7 +193,7 @@ For more information, see our post on [disabling SIMD](@/edition-2/posts/02-mini
 "rustc-abi": "x86-softfloat"
 ```
 
-As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `rustc-abi` field to `x86-softfloat`.
 
 #### Putting it Together
 Our target specification file now looks like this:

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ru.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ru.md
@@ -198,7 +198,7 @@ Cargo поддерживает различные целевые системы 
 "rustc-abi": "x86-softfloat"
 ```
 
-As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `rustc-abi` field to `x86-softfloat`.
 
 #### Соединяем все вместе
 

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.zh-CN.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.zh-CN.md
@@ -165,7 +165,7 @@ Nightly 版本的编译器允许我们在源码的开头插入**特性标签**�
 "rustc-abi": "x86-softfloat"
 ```
 
-As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.
+As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `rustc-abi` field to `x86-softfloat`.
 
 现在，我们将各个配置项整合在一起。我们的目标配置清单应该长这样：
 


### PR DESCRIPTION
Post 02 currently states...

> As we want to use the `soft-float` feature, we also need to tell the Rust compiler `rustc` that we want to use the corresponding ABI. We can do that by setting the `x86-softfloat` field to `x86-softfloat`.

...when the field name should be `rustc-abi`.

I've updated this for all localizations.