### PR TITLE
Fix the missing '&' in post 09

### DIFF
--- a/blog/content/edition-2/posts/09-paging-implementation/index.md
+++ b/blog/content/edition-2/posts/09-paging-implementation/index.md
@@ -399,7 +399,7 @@ pub unsafe fn active_level_4_table(physical_memory_offset: VirtAddr)
     let virt = physical_memory_offset + phys.as_u64();
     let page_table_ptr: *mut PageTable = virt.as_mut_ptr();
 
-    unsafe { mut *page_table_ptr }
+    unsafe { &mut *page_table_ptr }
 }
 ```
 


### PR DESCRIPTION
There's a missing '&' in [some code snippet](https://github.com/phil-opp/blog_os/blob/98f616964da8eb04fa76998be739431016904254/blog/content/edition-2/posts/09-paging-implementation/index.md?plain=1#L402) of post 09. I added it.
