### PR TITLE
Fix: `target-c-int-width` field now expects an integer

### DIFF
--- a/x86_64-blog_os.json
+++ b/x86_64-blog_os.json
@@ -4,7 +4,7 @@
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",
-    "target-c-int-width": "32",
+    "target-c-int-width": 32,
     "os": "none",
     "executables": true,
     "linker-flavor": "ld.lld",


### PR DESCRIPTION
Fixes the build on latest Rust nightlies.