### PR TITLE
Set `test=true` to enable `main.rs` testing again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ features = ["spin_no_std"]
 
 [[bin]]
 name = "blog_os"
-test = false
+test = true
 bench = false
 
 


### PR DESCRIPTION
We set `test=false` for previous posts in https://github.com/phil-opp/blog_os/pull/1412 to avoid errors e.g. in rust-analyzer. For this testing post, we want to set it back to `true`.

Fixes https://github.com/phil-opp/blog_os/issues/1433