### PR TITLE
Fix: theme reset button visibility logic

### DIFF
--- a/blog/sass/css/edition-2/main.scss
+++ b/blog/sass/css/edition-2/main.scss
@@ -1050,8 +1050,7 @@ img {
     cursor: pointer;
     opacity: 0.6;
 
-    display: none; // Remove CSS-based visibility logic entirely
-
+    display: none;
     [data-theme="dark"] & {
         @include light-switch-reset-dark();
     }

--- a/blog/static/js/edition-2/main.js
+++ b/blog/static/js/edition-2/main.js
@@ -12,7 +12,7 @@ window.onload = function () {
       set_giscus_theme(theme)
     }, 500);
   }
-  clear_theme_visiblity();
+  clear_theme_visibility();
 }
 
 function resize_toc(container) {
@@ -68,7 +68,7 @@ function toc_scroll_position(container) {
   }
 }
 
-function clear_theme_visiblity() {
+function clear_theme_visibility() {
     const resetButton = document.querySelector('.light-switch-reset');
     const currentTheme = localStorage.getItem("theme");
     const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
@@ -91,7 +91,7 @@ function toggle_lights() {
   } else {
     set_theme(window.matchMedia("(prefers-color-scheme: dark)").matches ? "light" : "dark")
   }
-  clear_theme_visiblity();
+  clear_theme_visibility();
 }
 
 function set_theme(theme) {
@@ -104,7 +104,7 @@ function clear_theme_override() {
   document.documentElement.removeAttribute("data-theme");
   set_giscus_theme("preferred_color_scheme")
   localStorage.removeItem("theme")
-  clear_theme_visiblity();
+  clear_theme_visibility();
 }
 
 function set_giscus_theme(theme) {


### PR DESCRIPTION
## Problem
The theme reset button currently shows whenever any theme override is active, even when clicking it would produce no visible change. 
For example:
- System preference: Light theme
- Website override: Light theme  
- Reset button: Shows but clicking does nothing (already matches system)

This creates a confusing user experience where the button appears functional but provides no feedback.

## Solution
- ✅ **Show reset button** when override differs from system preference
- ❌ **Hide reset button** when override matches system preference or no override exists

i removed the visiblity rules from scss file and used clear_theme_visiblity() function to implement the visblity logic

## Before/After Behavior

| System Theme | Website Override | Before | After | Result |
|-------------|------------------|--------|-------|---------|
| Light | Dark | Shows | ✅ Shows | Clear visual feedback |
| Dark | Light | Shows | ✅ Shows | Clear visual feedback |
| Light | Light | Shows | ❌ Hidden | No confusing "broken" button |
| Dark | Dark | Shows | ❌ Hidden | No confusing "broken" button |
| Any | None | Hidden | ❌ Hidden | Consistent behavior |
