### PR TITLE
fix: lazy_static is not needed, keyboard methods are const, 

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -70,14 +70,11 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: InterruptStac
     use spin::Mutex;
     use x86_64::instructions::port::Port;
 
-    lazy_static! {
-        static ref KEYBOARD: Mutex<Keyboard<layouts::Us104Key, ScancodeSet1>> =
-            Mutex::new(Keyboard::new(
-                ScancodeSet1::new(),
-                layouts::Us104Key,
-                HandleControl::Ignore
-            ));
-    }
+    static KEYBOARD: Mutex<Keyboard<layouts::Us104Key, ScancodeSet1>> = Mutex::new(Keyboard::new(
+        ScancodeSet1::new(),
+        layouts::Us104Key,
+        HandleControl::Ignore,
+    ));
 
     let mut keyboard = KEYBOARD.lock();
     let mut port = Port::new(0x60);


### PR DESCRIPTION
compile time initialization is possible for keyboard.

pub const fn Keyboard::new
pub const fn ScancodeSet1::new