### PR TITLE
Updated spin crate version from 0.5.2 to 0.10.0

### DIFF
--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.ar.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.ar.md
@@ -568,7 +568,7 @@ lazy_static! {
 ```toml
 # in Cargo.toml
 [dependencies]
-spin = "0.5.2"
+ spin = "0.10.0"
 ```
 
 ثم يمكننا استخدام spinning mutex لإضافة [قابلية تعديل داخلية][interior mutability] آمنة إلى `WRITER` الثابت:

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.fa.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.fa.md
@@ -545,7 +545,7 @@ lazy_static! {
 ```toml
 # in Cargo.toml
 [dependencies]
-spin = "0.5.2"
+ spin = "0.10.0"
 ```
 
 سپس می توانیم از spinning Mutex برای افزودن [تغییر پذیری داخلی] امن به `WRITER` استاتیک خود استفاده کنیم:

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.fr.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.fr.md
@@ -568,7 +568,7 @@ Pour utiliser un mutex tournant, nous pouvons ajouter la [crate spin] comme dép
 ```toml
 # dans Cargo.toml
 [dependencies]
-spin = "0.5.2"
+ spin = "0.10.0"
 ```
 
 Ensuite, nous pouvons utiliser le mutex tournant pour ajouter une [mutabilité intérieure] sûre à notre `WRITER` statique :

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.ja.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.ja.md
@@ -558,7 +558,7 @@ lazy_static! {
 ```toml
 # in Cargo.toml
 [dependencies]
-spin = "0.5.2"
+ spin = "0.10.0"
 ```
 
 すると、スピンを使ったMutexを使うことができ、静的な`WRITER`に安全な[内部可変性][interior mutability]を追加できます。

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.ko.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.ko.md
@@ -544,7 +544,7 @@ lazy_static! {
 ```toml
 # in Cargo.toml
 [dependencies]
-spin = "0.5.2"
+ spin = "0.10.0"
 ```
 
 이제 스핀 락을 이용해 전역 변수 `WRITER`에 안전하게 [내부 가변성 (interior mutability)][interior mutability] 을 구현할 수 있습니다:

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.md
@@ -542,7 +542,7 @@ To use a spinning mutex, we can add the [spin crate] as a dependency:
 ```toml
 # in Cargo.toml
 [dependencies]
-spin = "0.5.2"
+ spin = "0.10.0"
 ```
 
 Then we can use the spinning mutex to add safe [interior mutability] to our static `WRITER`:

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.pt-BR.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.pt-BR.md
@@ -546,7 +546,7 @@ Para usar um spinning mutex, podemos adicionar a [crate spin] como uma dependên
 ```toml
 # em Cargo.toml
 [dependencies]
-spin = "0.5.2"
+ spin = "0.10.0"
 ```
 
 Então podemos usar o spinning mutex para adicionar [mutabilidade interior] segura ao nosso `WRITER` static:

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.zh-CN.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.zh-CN.md
@@ -500,7 +500,7 @@ lazy_static! {
 ```toml
 # in Cargo.toml
 [dependencies]
-spin = "0.5.2"
+ spin = "0.10.0"
 ```
 
 现在，我们能够使用自旋的互斥锁，为我们的 `WRITER` 类实现安全的[内部可变性](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html)：


### PR DESCRIPTION
There is no big api changes with spin::Mutex so this change should be safe.