### PR TITLE
Fix target spec: use `softfloat` instead of `x86-softfloat`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,6 @@ dependencies = [
 
 [[package]]
 name = "bootloader"
-version = "0.9.33"
+version = "0.9.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdfddac270bbdd45903296bc1caf29a7fdce6b326aaf0bbab7f04c5f98b7447"
+checksum = "e22d5a0b9e11dd5bee9d24a68885de6dc7ed367f897323b1c1286150fd469374"

--- a/x86_64-blog_os.json
+++ b/x86_64-blog_os.json
@@ -12,5 +12,5 @@
     "panic-strategy": "abort",
     "disable-redzone": true,
     "features": "-mmx,-sse,+soft-float",
-    "rustc-abi": "x86-softfloat"
+    "rustc-abi": "softfloat"
   }


### PR DESCRIPTION
The compatibility alias `x86-softfloat` was removed in https://github.com/rust-lang/rust/pull/157151.
