### PR TITLE
Update GDT and VirtAddr code to x86_64 v0.15

### DIFF
--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -13,7 +13,7 @@ lazy_static! {
             static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
 
             let stack_start = VirtAddr::from_ptr(&raw const STACK);
-            let stack_end = stack_start + STACK_SIZE;
+            let stack_end = stack_start + STACK_SIZE as u64;
             stack_end
         };
         tss
@@ -23,8 +23,8 @@ lazy_static! {
 lazy_static! {
     static ref GDT: (GlobalDescriptorTable, Selectors) = {
         let mut gdt = GlobalDescriptorTable::new();
-        let code_selector = gdt.add_entry(Descriptor::kernel_code_segment());
-        let tss_selector = gdt.add_entry(Descriptor::tss_segment(&TSS));
+        let code_selector = gdt.append(Descriptor::kernel_code_segment());
+        let tss_selector = gdt.append(Descriptor::tss_segment(&TSS));
         (
             gdt,
             Selectors {


### PR DESCRIPTION
- The `add_entry` method is named `append` now
- `VirtAddr` no longer impls `Add<usize>`

Follow-up to https://github.com/phil-opp/blog_os/pull/1493