### PR TITLE
Update `pic8259` dependency to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "spin 0.5.2",
  "uart_16550",
  "volatile 0.2.7",
- "x86_64 0.15.5",
+ "x86_64",
 ]
 
 [[package]]
@@ -57,11 +57,11 @@ checksum = "ed089a1fbffe3337a1a345501c981f1eb1e47e69de5a40e852433e12953c3174"
 
 [[package]]
 name = "pic8259"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb844b5b01db1e0b17938685738f113bfc903846f18932b378bc0eabfa40e194"
+checksum = "62d9a86c292b165f757e47e7fd66855def189b2564609bc4203727b27c33db22"
 dependencies = [
- "x86_64 0.14.13",
+ "x86_64",
 ]
 
 [[package]]
@@ -102,18 +102,6 @@ name = "volatile"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
-
-[[package]]
-name = "x86_64"
-version = "0.14.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c101112411baafbb4bf8d33e4c4a80ab5b02d74d2612331c61e8192fc9710491"
-dependencies = [
- "bit_field",
- "bitflags",
- "rustversion",
- "volatile 0.4.6",
-]
 
 [[package]]
 name = "x86_64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ volatile = "0.2.6"
 spin = "0.5.2"
 x86_64 = "0.15.5"
 uart_16550 = "0.6.0"
-pic8259 = "0.10.1"
+pic8259 = "0.11.0"
 pc-keyboard = "0.7.0"
 
 [dependencies.lazy_static]


### PR DESCRIPTION
Follow-up to https://github.com/phil-opp/blog_os/pull/1493 and https://github.com/phil-opp/blog_os/pull/1495

Upgrading `pic8259` unifies the x86_64 dependency again (the older `pic8259` version still used `x86_64` v0.14).