### PR TITLE
Fix: `VirtAddr` does no longer implement `Add<usize>`

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -20,7 +20,7 @@ pub fn init_heap(
 ) -> Result<(), MapToError<Size4KiB>> {
     let page_range = {
         let heap_start = VirtAddr::new(HEAP_START as u64);
-        let heap_end = heap_start + HEAP_SIZE - 1u64;
+        let heap_end = heap_start + HEAP_SIZE as u64 - 1u64;
         let heap_start_page = Page::containing_address(heap_start);
         let heap_end_page = Page::containing_address(heap_end);
         Page::range_inclusive(heap_start_page, heap_end_page)


### PR DESCRIPTION
Part of the upgrade to x86_64 v0.15 (https://github.com/phil-opp/blog_os/pull/1493)