### PR TITLE
Link comment discussions by ID if existing

### DIFF
--- a/blog/content/edition-2/extra/building-on-android/index.md
+++ b/blog/content/edition-2/extra/building-on-android/index.md
@@ -2,6 +2,9 @@
 title = "Building on Android"
 weight = 3
 aliases = ["second-edition/extra/building-on-android/index.html"]
+
+[extra]
+comments_search_term = 1020
 +++
 
 I finally managed to get `blog_os` building on my Android phone using [termux](https://termux.com/). This post explains the necessary steps to set it up.

--- a/blog/content/edition-2/posts/01-freestanding-rust-binary/index.ko.md
+++ b/blog/content/edition-2/posts/01-freestanding-rust-binary/index.ko.md
@@ -5,6 +5,7 @@ path = "ko/freestanding-rust-binary"
 date = 2018-02-10
 
 [extra]
+comments_search_term = 1255
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/01-freestanding-rust-binary/index.md
+++ b/blog/content/edition-2/posts/01-freestanding-rust-binary/index.md
@@ -5,6 +5,7 @@ path = "freestanding-rust-binary"
 date = 2018-02-10
 
 [extra]
+comments_search_term = 997
 chapter = "Bare Bones"
 
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/01-freestanding-rust-binary/index.ru.md
+++ b/blog/content/edition-2/posts/01-freestanding-rust-binary/index.ru.md
@@ -5,6 +5,7 @@ path = "ru/freestanding-rust-binary"
 date = 2018-02-10
 
 [extra]
+comments_search_term = 1102
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 translators = ["MrZloHex"]

--- a/blog/content/edition-2/posts/01-freestanding-rust-binary/index.zh-CN.md
+++ b/blog/content/edition-2/posts/01-freestanding-rust-binary/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/freestanding-rust-binary"
 date = 2018-02-10
 
 [extra]
+comments_search_term = 1184
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/disable-red-zone/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/disable-red-zone/index.md
@@ -3,6 +3,9 @@ title = "Disable the Red Zone"
 weight = 1
 path = "red-zone"
 template = "edition-2/extra.html"
+
+[extra]
+comments_search_term = 1002
 +++
 
 The [red zone] is an optimization of the [System V ABI] that allows functions to temporarily use the 128 bytes below their stack frame without adjusting the stack pointer:

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/disable-red-zone/index.zh-CN.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/disable-red-zone/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/red-zone"
 template = "edition-2/extra.html"
 
 [extra]
+comments_search_term = 1375
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 +++

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.md
@@ -3,6 +3,9 @@ title = "Disable SIMD"
 weight = 2
 path = "disable-simd"
 template = "edition-2/extra.html"
+
+[extra]
+comments_search_term = 1001
 +++
 
 [Single Instruction Multiple Data (SIMD)] instructions are able to perform an operation (e.g., addition) simultaneously on multiple data words, which can speed up programs significantly. The `x86_64` architecture supports various SIMD standards:

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.zh-CN.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/disable-simd/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/disable-simd"
 template = "edition-2/extra.html"
 
 [extra]
+comments_search_term = 1330
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 +++

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ko.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ko.md
@@ -5,6 +5,7 @@ path = "ko/minimal-rust-kernel"
 date = 2018-02-10
 
 [extra]
+comments_search_term = 1256
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.md
@@ -5,6 +5,7 @@ path = "minimal-rust-kernel"
 date = 2018-02-10
 
 [extra]
+comments_search_term = 998
 chapter = "Bare Bones"
 +++
 

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ru.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.ru.md
@@ -5,6 +5,7 @@ path = "ru/minimal-rust-kernel"
 date = 2018-02-10
 
 [extra]
+comments_search_term = 1044
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 translators = ["MrZloHex"]

--- a/blog/content/edition-2/posts/02-minimal-rust-kernel/index.zh-CN.md
+++ b/blog/content/edition-2/posts/02-minimal-rust-kernel/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/minimal-rust-kernel"
 date = 2018-02-10
 
 [extra]
+comments_search_term = 1019
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.ja.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.ja.md
@@ -5,6 +5,7 @@ path = "ja/vga-text-mode"
 date  = 2018-02-26
 
 [extra]
+comments_search_term = 1156
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.ko.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.ko.md
@@ -5,6 +5,7 @@ path = "ko/vga-text-mode"
 date  = 2018-02-26
 
 [extra]
+comments_search_term = 1264
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.md
@@ -5,6 +5,7 @@ path = "vga-text-mode"
 date  = 2018-02-26
 
 [extra]
+comments_search_term = 999
 chapter = "Bare Bones"
 +++
 

--- a/blog/content/edition-2/posts/03-vga-text-buffer/index.zh-CN.md
+++ b/blog/content/edition-2/posts/03-vga-text-buffer/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/vga-text-mode"
 date  = 2018-02-26
 
 [extra]
+comments_search_term = 1085
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/04-testing/index.zh-CN.md
+++ b/blog/content/edition-2/posts/04-testing/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/testing"
 date = 2019-04-27
 
 [extra]
+comments_search_term = 1261
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/05-cpu-exceptions/index.md
+++ b/blog/content/edition-2/posts/05-cpu-exceptions/index.md
@@ -5,6 +5,7 @@ path = "cpu-exceptions"
 date  = 2018-06-17
 
 [extra]
+comments_search_term = 1004
 chapter = "Interrupts"
 +++
 

--- a/blog/content/edition-2/posts/05-cpu-exceptions/index.zh-CN.md
+++ b/blog/content/edition-2/posts/05-cpu-exceptions/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/cpu-exceptions"
 date  = 2018-06-17
 
 [extra]
+comments_search_term = 1325
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/06-double-faults/index.ko.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.ko.md
@@ -5,6 +5,7 @@ path = "ko/double-fault-exceptions"
 date  = 2018-06-18
 
 [extra]
+comments_search_term = 1260
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/06-double-faults/index.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.md
@@ -5,6 +5,7 @@ path = "double-fault-exceptions"
 date  = 2018-06-18
 
 [extra]
+comments_search_term = 1005
 chapter = "Interrupts"
 +++
 

--- a/blog/content/edition-2/posts/06-double-faults/index.zh-CN.md
+++ b/blog/content/edition-2/posts/06-double-faults/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/double-fault-exceptions"
 date  = 2018-06-18
 
 [extra]
+comments_search_term = 1214
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/07-hardware-interrupts/index.fa.md
+++ b/blog/content/edition-2/posts/07-hardware-interrupts/index.fa.md
@@ -5,6 +5,7 @@ path = "fa/hardware-interrupts"
 date = 2018-10-22
 
 [extra]
+comments_search_term = 1450
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/07-hardware-interrupts/index.md
+++ b/blog/content/edition-2/posts/07-hardware-interrupts/index.md
@@ -5,6 +5,7 @@ path = "hardware-interrupts"
 date = 2018-10-22
 
 [extra]
+comments_search_term = 1003
 chapter = "Interrupts"
 +++
 

--- a/blog/content/edition-2/posts/07-hardware-interrupts/index.zh-CN.md
+++ b/blog/content/edition-2/posts/07-hardware-interrupts/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/hardware-interrupts"
 date = 2018-10-22
 
 [extra]
+comments_search_term = 1200
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/08-paging-introduction/index.md
+++ b/blog/content/edition-2/posts/08-paging-introduction/index.md
@@ -5,6 +5,7 @@ path = "paging-introduction"
 date = 2019-01-14
 
 [extra]
+comments_search_term = 1011
 chapter = "Memory Management"
 +++
 

--- a/blog/content/edition-2/posts/08-paging-introduction/index.zh-CN.md
+++ b/blog/content/edition-2/posts/08-paging-introduction/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/paging-introduction"
 date = 2019-01-14
 
 [extra]
+comments_search_term = 1326
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/09-paging-implementation/index.md
+++ b/blog/content/edition-2/posts/09-paging-implementation/index.md
@@ -5,6 +5,7 @@ path = "paging-implementation"
 date = 2019-03-14
 
 [extra]
+comments_search_term = 1013
 chapter = "Memory Management"
 +++
 

--- a/blog/content/edition-2/posts/09-paging-implementation/index.zh-CN.md
+++ b/blog/content/edition-2/posts/09-paging-implementation/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/paging-implementation"
 date = 2019-03-14
 
 [extra]
+comments_search_term = 1205
 # Please update this when updating the translation
 translation_based_on_commit = "1132d7a3835dc6c0b3fd8f6b45c9295a9bc1f837"
 # GitHub usernames of the people that translated this post

--- a/blog/content/edition-2/posts/10-heap-allocation/index.md
+++ b/blog/content/edition-2/posts/10-heap-allocation/index.md
@@ -5,6 +5,7 @@ path = "heap-allocation"
 date = 2019-06-26
 
 [extra]
+comments_search_term = 1014
 chapter = "Memory Management"
 +++
 

--- a/blog/content/edition-2/posts/11-allocator-designs/index.md
+++ b/blog/content/edition-2/posts/11-allocator-designs/index.md
@@ -5,6 +5,7 @@ path = "allocator-designs"
 date = 2020-01-20
 
 [extra]
+comments_search_term = 1016
 chapter = "Memory Management"
 +++
 

--- a/blog/content/edition-2/posts/12-async-await/index.md
+++ b/blog/content/edition-2/posts/12-async-await/index.md
@@ -5,6 +5,7 @@ path = "async-await"
 date = 2020-03-27
 
 [extra]
+comments_search_term = 1018
 chapter = "Multitasking"
 +++
 

--- a/blog/content/edition-2/posts/12-async-await/index.zh-CN.md
+++ b/blog/content/edition-2/posts/12-async-await/index.zh-CN.md
@@ -5,6 +5,7 @@ path = "zh-CN/async-await"
 date = 2020-03-27
 
 [extra]
+comments_search_term = 1446
 chapter = "Multitasking"
 
 # Please update this when updating the translation

--- a/blog/content/edition-2/posts/deprecated/04-unit-testing/index.md
+++ b/blog/content/edition-2/posts/deprecated/04-unit-testing/index.md
@@ -5,6 +5,7 @@ path = "unit-testing"
 date  = 2018-04-29
 
 [extra]
+comments_search_term = 1008
 warning_short = "Deprecated: "
 warning = "This post is deprecated in favor of the [_Testing_](/testing) post and will no longer receive updates."
 +++

--- a/blog/content/edition-2/posts/deprecated/05-integration-tests/index.md
+++ b/blog/content/edition-2/posts/deprecated/05-integration-tests/index.md
@@ -5,6 +5,7 @@ path = "integration-tests"
 date  = 2018-06-15
 
 [extra]
+comments_search_term = 1006
 warning_short = "Deprecated: "
 warning = "This post is deprecated in favor of the [_Testing_](/testing) post and will no longer receive updates."
 +++

--- a/blog/content/edition-2/posts/deprecated/10-advanced-paging/index.md
+++ b/blog/content/edition-2/posts/deprecated/10-advanced-paging/index.md
@@ -5,6 +5,7 @@ path = "advanced-paging"
 date = 2019-01-28
 
 [extra]
+comments_search_term = 1012
 warning_short = "Deprecated: "
 warning = "This post is deprecated in favor of the [_Paging Implementation_](/paging-implementation) post and will no longer receive updates. See issue [#545](https://github.com/phil-opp/blog_os/issues/545) for reasons for this deprecation."
 +++

--- a/blog/content/news/2018-03-09-pure-rust.md
+++ b/blog/content/news/2018-03-09-pure-rust.md
@@ -2,6 +2,9 @@
 title = "Writing an OS in pure Rust"
 date = 2018-03-09
 aliases = ["news/2018-03-09-pure-rust"]
+
+[extra]
+comments_search_term = 1000
 +++
 
 Over the past six months we've been working on a second edition of this blog. Our goals for this new version are [numerous] and we are still not done yet, but today we reached a major milestone: It is now possible to build the OS natively on Windows, macOS, and Linux **without any non-Rust dependendencies**.

--- a/blog/content/status-update/2019-07-06.md
+++ b/blog/content/status-update/2019-07-06.md
@@ -2,6 +2,9 @@
 title = "Updates in June 2019"
 date = 2019-07-06
 aliases = ["status-update/2019-06-04/index.html"]
+
+[extra]
+comments_search_term = 1015
 +++
 
 This post gives an overview of the recent updates to the _Writing an OS in Rust_ blog and the used libraries and tools.

--- a/blog/content/status-update/2019-09-09.md
+++ b/blog/content/status-update/2019-09-09.md
@@ -1,6 +1,9 @@
 +++
 title = "Updates in August 2019"
 date = 2019-09-09
+
+[extra]
+comments_search_term = 995
 +++
 
 This post gives an overview of the recent updates to the _Writing an OS in Rust_ blog and the used libraries and tools.

--- a/blog/content/status-update/2020-03-02.md
+++ b/blog/content/status-update/2020-03-02.md
@@ -1,6 +1,9 @@
 +++
 title = "Updates in February 2020"
 date = 2020-03-02
+
+[extra]
+comments_search_term = 1017
 +++
 
 This post gives an overview of the recent updates to the _Writing an OS in Rust_ blog and the corresponding libraries and tools.

--- a/blog/content/status-update/2020-04-01/index.md
+++ b/blog/content/status-update/2020-04-01/index.md
@@ -1,6 +1,9 @@
 +++
 title = "Updates in March 2020"
 date = 2020-04-01
+
+[extra]
+comments_search_term = 1204
 +++
 
 This post gives an overview of the recent updates to the _Writing an OS in Rust_ blog and the corresponding libraries and tools.

--- a/blog/templates/edition-2/extra.html
+++ b/blog/templates/edition-2/extra.html
@@ -17,6 +17,12 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus(search_term=page.title ~ " (Extra Post)", lang=page.lang) }}
+
+        {% if page.extra.comments_search_term %}
+            {% set search_term=page.extra.comments_search_term %}
+        {% else %}
+            {% set search_term=page.title ~ " (Extra Post)" %}
+        {% endif %}
+        {{ snippets::giscus(search_term=search_term, lang=page.lang) }}
     </section>
 {% endblock after_main %}

--- a/blog/templates/news-page.html
+++ b/blog/templates/news-page.html
@@ -17,7 +17,13 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus(search_term=page.title ~ " (News Post)", lang=page.lang) }}
+
+        {% if page.extra.comments_search_term %}
+            {% set search_term=page.extra.comments_search_term %}
+        {% else %}
+            {% set search_term=page.title ~ " (News Post)" %}
+        {% endif %}
+        {{ snippets::giscus(search_term=search_term, lang=page.lang) }}
     </section>
 
 {% endblock after_main %}

--- a/blog/templates/status-update-page.html
+++ b/blog/templates/status-update-page.html
@@ -32,7 +32,13 @@
     <hr>
     <section>
         <h2 id="comments">Comments</h2>
-        {{ snippets::giscus(search_term=page.title, lang=page.lang) }}
+
+        {% if page.extra.comments_search_term %}
+            {% set search_term=page.extra.comments_search_term %}
+        {% else %}
+            {% set search_term=page.title %}
+        {% endif %}
+        {{ snippets::giscus(search_term=search_term, lang=page.lang) }}
     </section>
 
 {% endblock after_main %}


### PR DESCRIPTION
Avoids the creation of duplicate threads when the GitHub search API has issues. Examples of duplicate threads are #1490, #1491, #1492, and #1467.
